### PR TITLE
Next small changes

### DIFF
--- a/docs/ntppool/de/homepage/intro.html
+++ b/docs/ntppool/de/homepage/intro.html
@@ -1,19 +1,19 @@
 <p>
  Das pool.ntp.org Projekt ist ein gro&szlig;er virtueller Cluster aus
- Zeitservern, der nachhaltig und auf <a href="use.html">einfache Weise</a>
- Zeitsynchronisation &uuml;ber NTP f&uuml;r mehrere Millionen Clienten zur
+ Zeitservern, der verl&auml;sslich und auf <a href="use.html">einfache Weise</a>
+ Zeitsynchronisation &uuml;ber NTP f&uuml;r mehrere Millionen Computer zur
  Verf&uuml;gung stellt.
 </p>
 <p>
  Der Pool wird von mehreren Millionen Systemen auf der ganzen Welt eingesetzt.
- Er ist der standard Zeitserver f&uuml;r viele linuxbasierte Betriebsysteme und
- einige Netzwerkger&auml;te (siehe <a href="vendors.html">Information f&uuml;r
-  Hersteller</a>).
+ Er ist der "Standard-Zeitserver" f&uuml;r die meisten der linuxbasierten
+ Betriebsysteme und einige Netzwerkger&auml;te (siehe
+ <a href="vendors.html">Information f&uuml;r Hersteller</a>).
 </p>
 <p>
  Aufgrund der gro&szlig;en Nachfrage ben&ouml;tigen wir auch in Zukunft weitere
  Server, die bei der Verteilung der Zeit mitwirken. Sollten Sie &uuml;ber einen
- Server mit statischer IP-Adresse verf&uuml;gen, der permanten mit dem Internet
+ Server mit statischer IP-Adresse verf&uuml;gen, der permant mit dem Internet
  verbunden ist, erw&auml;gen Sie bitte eine <a href="join.html">Aufnahme Ihres
  Systems in den NTP Pool</a>.
 </p>

--- a/docs/ntppool/de/join/configuration.html
+++ b/docs/ntppool/de/join/configuration.html
@@ -5,23 +5,23 @@
 <p>
  Der <a href="http://support.ntp.org/bin/view/Support/WebHome">Support</a> auf
  <a href="http://support.ntp.org/">support.ntp.org</a> verf&uuml;gt &uuml;ber
- einige Informationen. bez&uuml;glich des NTP-Protokolls.
+ eine Menge n&uuml;tzlicher Informationen bez&uuml;glich des NTP-Protokolls.
 </p>
 
 <p>
- Wenn Sie den NTP Pool lediglich benutzen m&ouml;chten, lesen Sie bitte
+ Wenn Sie den NTP Pool lediglich <i>benutzen</i> m&ouml;chten, lesen Sie bitte
  die <a href="/use.html">Wie benutze ich den NTP Pool?</a> Seite.
 </p>
 
 <p>
  Als eine weitere Anlaufstelle dient die <a
   href="http://groups.google.com/group/comp.protocols.time.ntp">comp.protocols.time.ntp</a>
-  Newsgruppe. Dort wird Ihnen beim Einsatz der NTP Sofware geholfen.
+  Newsgruppe. Dort wird Ihnen beim Einsatz der NTP Sofware selbst geholfen.
 </p>
 
 <p>
- Im Folgenden werden einige relevante Informationen f&uuml;r den Betrieb eines
- Zeitserver im NTP Pool beschrieben.
+ Im Folgenden werden einige relevante Informationen f&uuml;r den Betrieb Ihres
+ Zeitservers im NTP Pool beschrieben.
 </p>
 
 <h4>Setup f&uuml;r etwa 5 Server</h4>
@@ -41,15 +41,15 @@
 <h4>Benutzen Sie nicht *.pool.ntp.org als Zeitserver</h4>
 
 <p>
- Um die Qualit&auml;t der Zeitsynchronisation zu halten, sollten Sie nicht auf
- eine der <tt>*.pool.ntp.org</tt> Aliase in Ihrer Konfiguration
- zur&uuml;ckgreifen.
+ Um die Qualit&auml;t der Zeitsynchronisation zu halten, sollten Sie
+ ironischerweise keine der <tt>*.pool.ntp.org</tt> Adressen in Ihrer
+ Konfiguration benutzen.
 </p>
 
 <p>
  F&uuml;r einen robusten und gesunden Pool ist es das Beste, Sie w&auml;hlen den
  f&uuml;r Sie am besten funktionierenden Zeitserver in Ihrer Umgebung. Das
- NTP.org Wiki hat daf&uuml;r ein <a
+ NTP.org Wiki hat daf&uuml;r eine <a
  href="http://support.ntp.org/bin/view/Servers/WebHome">Liste &ouml;ffentlicher
  Server</a>.
 </p>
@@ -68,10 +68,16 @@
  offiziellen <a
  href="http://support.ntp.org/bin/view/Main/SoftwareDownloads">ntpd</a>.
 </p>
+<p>
+ Sie k&ouml;nnen den Pool mit jedem Programm, das NTP spricht, <i>benutzen</i>,
+ wollen Sie dem Pool aber beitreten, empfehlen wir den Einsatz des
+ <a href="http://support.ntp.org/bin/view/Main/SoftwareDownloads">ntpd</a>.
+</p>
 
 <h4>Nutzen Sie nicht die lokale Uhrzeit</h4>
 
-<p>Server im NTP Pool sollten auf den Einsatz der lokalen Uhrzeit
- verzichten.</p>
+<p>
+ Server im NTP Pool sollten auf den Einsatz der lokalen Uhrzeit verzichten.
+</p>
 
 </div>

--- a/docs/ntppool/de/tpl/server/graph_explanation.html
+++ b/docs/ntppool/de/tpl/server/graph_explanation.html
@@ -15,7 +15,7 @@
  von blaub f&uuml;r sehr kleine Fehler &uuml;ber gelb und orange bis rot, falls
  der Zeitfehler mehrere Sekunden betr&auml;gt oder Ihr Server nicht erreichbar ist.
  Durch die eingesetzte Mittelung kann es teilweise sehr schwer werden auf die
- Ursache des Punkteabzugs zu schlie&szlig;en. Das Diagram dient lediglich als
+ Ursache des Punkteabzugs zu schlie&szlig;en. Das Diagramm dient lediglich als
  Werkzeug zur Visualisierung eines Trends. Die exakten Ergebnisse des
  &Uuml;berwachungssystems k&ouml;nnen als CSV-Datei heruntergeladen werden.
 </p>

--- a/docs/ntppool/de/use.html
+++ b/docs/ntppool/de/use.html
@@ -4,9 +4,9 @@
  <h3><a name="use"></a>Wie benutze ich pool.ntp.org?</h3>
 
  <p>
-  Zur Synchronisation der Uhrzeit Ihres Computers nutzen Sie folgende
-  Konfiguration f&uuml;r den <a href="http://www.ntp.org">ntpd</a> Dienst,
-  unabh&auml;ngig davon, welches Betriebssystem Sie einsetzen:
+  Zur Synchronisation der Uhrzeit Ihres Computers nutzen Sie die folgende,
+  einfache Konfiguration f&uuml;r den <a href="http://www.ntp.org">ntpd</a>
+  Dienst, unabh&auml;ngig davon, welches Betriebssystem Sie einsetzen:
  </p>
 
 <pre class="code">
@@ -17,8 +17,8 @@ server 1.pool.ntp.org
 server 2.pool.ntp.org
 server 3.pool.ntp.org</pre>
  <p>
-  Die Ziffern 0, 1 und 2 zusammen mit <i>pool.ntp.org</i> zeigen auf
-  einen Satz von Severn, der st&uuml;ndlich &auml;ndert. Bevor der
+  Die Ziffern 0, 1, 2 und 3 zusammen mit <i>pool.ntp.org</i> zeigen auf
+  einen Satz von Servern, der sich st&uuml;ndlich &auml;ndert. Bevor der
   <i>ntpd</i>-Dienst gestartet werden kann, muss die Systemzeit grob (im
   Bereich weniger Minuten) eingestellt werden. Das kann manuell mit
   <tt>date</tt> oder &uuml;ber den NTP Pool mit <tt>ntpdate
@@ -37,27 +37,28 @@ remote           refid      st t when poll reach   delay   offset  jitter
 </pre> 
  <p>
   Die IP-Adressen werden andere sein, da zuf&auml;llige Zeitserver aus
-  dem NTP Pool eingesetzt werden. Ausschlaggeben ist, dass einer der
+  dem NTP Pool eingesetzt werden. Ausschlaggebend ist, dass einer der
   Zeitserver mit einem Stern (<tt>*</tt>) markiert ist. Erst dann wird
-  die Systemzeit mit dem Internet synchronisiert.
+  die Systemzeit mit dem Internet synchronisiert und Sie m&uuml;ssen sich
+  ab jetzt nicht mehr darum sorgen.
  </p>
  <p>
-  Nachdem <tt>pool.ntp.org</tt> zuf&auml;llige Zeitserver aus der ganzen
+  Da <tt>pool.ntp.org</tt> zuf&auml;llige Zeitserver aus der ganzen
   Welt zuweist, kann es zu einer ungenauen Synchronisation kommen. F&uuml;r
-  bessere Ergebnisse empfielt es sich, einer der
-  <a href="/zone/@">kontinentalen Zonen</a> (z.B.
+  etwas bessere Ergebnisse empfielt es sich, eine der
+  <a href="/zone/@">kontinentalen Zonen</a> (z. B.
   <a href="/zone/europe">europe</a>,
   <a href="/zone/north-america">north-america</a>,
   <a href="/zone/oceania">oceania</a>
   oder <a href="/zone/asia">asia</a>.pool.ntp.org),
-  oder gar noch besser eine L&auml;nderszone, wie zum Beispiel
+  oder gar noch besser eine L&auml;nderzone wie zum Beispiel
   <i>ch.pool.ntp.org</i> in der Schweiz oder <i>de.pool.ntp.org</i> in
-  Deutschland, zu benutzen. Auch in diesen Zonen k&ouml;nnen die Ziffern 0,
-  1 oder 2 vorangestellt werden (z.B. 0.de.pool.ntp.org)
+  Deutschland zu benutzen. Auch in diesen Zonen k&ouml;nnen wieder die Ziffern
+  0, 1, 2 oder 3 vorangestellt werden (z. B. 0.de.pool.ntp.org).
   Bitte beachten Sie, dass nicht alle L&auml;nderzonen existieren, oder
-  nur wenige Zeitserver enthalten sind. Sollten Sie einen Zeitserver
-  kennen, der sich in Ihrere N&auml;he befindet, wird die
-  Zeitsynchronisation damit vermutlich am besten sein.
+  darin nur wenige Zeitserver enthalten sein k&ouml;nnen. Sollten Sie einen
+  Zeitserver kennen, der sich in Ihrer N&auml;he befindet, wird die
+  Zeitsynchronisation damit vermutlich besser sein.
  </p>
  <p>
   Sollten Sie eine neuere Version von <b>Windows</b> einsetzten,
@@ -68,16 +69,17 @@ remote           refid      st t when poll reach   delay   offset  jitter
 net time /setsntp:pool.ntp.org
 </pre>
  <p>
-  Manche Versionen von Windows erlauben das Setzen mehrerer Zeitserver:
+  Manche Versionen von Windows erlauben, mehrere Zeitserver zu setzen:
 <pre class="code">
 net time /setsntp:"0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org"
 </pre>
  </p>
  <p>
   Dieses Vorgehen wurde f&uuml;r Windows 2000/XP/2003 gepr&uuml;ft. Das
-  gleiche kann als Administrator erreichen, wenn man mit Rechts auf die
-  Uhrzeit in der Systemleiste klickt und dann auf &quot;Einstellungen&quot;. Dort kann der Zeitserver
-  bzw. die Zone unter &quot;Internetzeit&quot; eingetragen werden.
+  gleiche kann als Administrator erreicht werden, wenn Sie mit Rechts auf die
+  Uhrzeit in der Systemleiste klickt und dann auf &quot;Einstellungen&quot;.
+  Dort kann der Zeitserver bzw. die Zone unter &quot;Internetzeit&quot;
+  eingetragen werden.
  </p>
 
  <p>
@@ -86,7 +88,7 @@ net time /setsntp:"0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org"
  </p>
 
  <p>
-  Sollten Sie sich innerhalb einer Dom&auml;ne befinden kann es sein, dass Sie
+  Sollten Sie sich innerhalb einer Dom&auml;ne befinden, kann es sein, dass Sie
   Ihre Systemzeit nicht unabh&auml;ngig definieren k&ouml;nnen. Mehr
   Informationen dazu liefert eine englische Problembeschreibung von Microsoft
   <a
@@ -100,18 +102,18 @@ net time /setsntp:"0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org"
  <p><span class="hook">Wenn Sie &uuml;ber eine statische IP-Adresse und eine
    vern&uuml;nftige Bandbreite verf&uuml;gen</span> (die Bandbreite ist weniger
   relevant als eine stabile Anbindung) erw&auml;gen Sie bitte, Ihren Server in
-  den NTP Pool mit aufzunehmen. Der zus&auml;tzliche enstehende Verkehr
+  den NTP Pool mit aufnehmen zu lassen. Der zus&auml;tzlich entstehende Verkehr
   betr&auml;gt im Allgemeinen nicht mehr als ein paar hundert Byte pro
   Sekunde, jedoch helfen Sie dabei, dieses Projekt am Leben zu halten. Bitte <a
-   href="/join.html">lesen Sie diese Beitrittsseite</a> f&uuml;r weitere
+   href="/join.html">lesen Sie die Beitrittsseite</a> f&uuml;r weitere
   Informationen.
  </p>
 
  <p><span class="hook">Verf&uuml;gt Ihr Internetanbieter &uuml;ber einen
-   Zeitserver</span>, oder kennen Sie einen guten Zeitserver in Ihrer
+   Zeitserver</span> oder Sie kennen einen guten Zeitserver in Ihrer
   N&auml;he, sollten Sie diesen nutzen anstelle des NTP Pools. Die
   Zeitsynchronisation wird dadurch besser und es werden weniger
-  Netzwerkressourcen des NTP Pools belegt. Selbstverst&auml;ndlich k&ouml;nnen
+  Netzwerkressourcen genutzt. Selbstverst&auml;ndlich k&ouml;nnen
   Sie die Zeitserver des NTP Pools auch zus&auml;tzlich zu den Ihnen bekanten
   Servern hinzuf&uuml;gen.</p>
 
@@ -122,28 +124,28 @@ net time /setsntp:"0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org"
   registriert sind, steigt jedoch die Wahrscheinlichkeit eines solchen Falles.
   Am besten setzten Sie dann auf kontinentale Zonen. In der <a
    href="/zone">Liste der Zonen</a> k&ouml;nnen Sie durch alle Zonen
-  bl&auml;ttern.</p>
+  bl&auml;tterni, um zu sehen wieviele Server sich in welcher Zone befinden.</p>
 
- <p><span class="hook">Sein Sie freundlich</span>. Viele Zeitserver werden von
+ <p><span class="hook">Seien Sie freundlich</span>. Viele Server werden von
   Freiwilligen betrieben und fast alle werden auch f&uuml;r private Zwecke
   eingesetzt. Also nutzen Sie bitte nicht mehr als drei Zeitserver
-  in Ihrer Konfiguration und benutzen Sie keine schmutzigen Tricks wie
+  in Ihrer Konfiguration und spielen Sie niemandem b&ouml;se Streiche mit
   <tt>burst</tt> oder <tt>minpoll</tt>. Das Einzige, was Sie damit erreichen
-  k&ouml;nnen ist, das dieses Projekt fr&uuml;her oder sp&auml;ter eingestellt
+  k&ouml;nnen ist, dass dieses Projekt fr&uuml;her oder sp&auml;ter eingestellt
   werden muss.</p>
 
- <p><span class="hook">Vergewissern Sie sich, dass Ihre
-   <i>Zeitzonenkonfiguration</i> korrekt ist</span>. <i>ntpd</i> selbst kennt
-  Ihre Zeitzone nicht.</p>
+ <p><span class="hook">Vergewissern Sie sich, dass die
+  <i>Zeitzonenkonfiguration</i> Ihres Computers korrekt ist</span>. <i>ntpd</i>
+  selbst kennt keine Zeitzonen - es arbeitet intern mit UTC.</p>
 
  <p><span class="hook">Wenn Sie ein Netzwerk mit pool.ntp.org synchronisieren
    m&ouml;chten</span>, setzen Sie bitte einen Ihrer Server als Zeitserver
   ein, der dann als einziger den NTP Pool nutzt und synchronisieren Sie alle anderen
   Computer mit diesem. Das Aufsetzten eines eigenen Zeitservers ist nicht
   weiter schwierig, erfordert allerdings ein paar Seiten der Anleitung zu lesen.
-  Bei Schwierigkeiten wird Ihnen Sicherlicht die <a href="news:comp.protocols.time.ntp"
+  Bei Schwierigkeiten wird Ihnen sicherlich die <a href="news:comp.protocols.time.ntp"
  >comp.protocols.time.ntp Newsgroup</a> weiterhelfen.</p>
 
- <p class="thanks">Schlie&szlig;lich m&ouml;chte ich allen danken, die Ihre
+ <p class="thanks">Zum Schluss m&ouml;chte ich allen danken, die Ihre
   Server dem NTP Pool zur Verf&uuml;gung stellen.</p>
 </div>


### PR DESCRIPTION
Hi Ask!

I worked on the rest of the documents in docs/ntppool/de now, again correcting some typos and few lexical errors, also adding one or two missing strings.

I noticed that in join.html the description does not take reference to 3.pool.ntp.org, only 0, 1 and 2 are mentioned. I added "3" to my translation - maybe you will want to correct that on the english pages, too.

Please merge these changes.

Regards,

Rob
