### PR TITLE
Swedish translation to be staged for beta review.

### DIFF
--- a/docs/ntppool/sv/homepage/intro.html
+++ b/docs/ntppool/sv/homepage/intro.html
@@ -1,0 +1,34 @@
+	<p>
+	Projektet pool.ntp.org är ett stort virtuellt kluster av tidsservrar
+	som ger en pålitlig och <a href="use.html">lättanvänd</a> NTP-tjänst
+        till miljoner användare.
+	</p>
+	<p>
+	Poolen utnyttjas av fler miljoner eller flera tiotal miljoner system
+	från hela världen.  Det är förstahandsvalet för &quot;Tidsserver&quot;
+	för de flesta av de större Linux-versionerna och för många internetanslutna
+	apparater.
+	(se <a href="vendors.html">information för tillverkare</a>).
+	</p>
+        <p>
+        På grund av det stora antalet användare behöver vi fler
+		servrar.  Om du har en server med statisk IP-adress, som 
+		alltid är ansluten till internet, överväg då att <a href="join.html">
+        lägga in den servern i systemet</a>.
+        </p>
+	<p>
+	Projektet sköts och utvecklas av
+	<a href="http://www.askbjoernhansen.com/">Ask Bj&oslash;rn
+	Hansen</a> och en stor stödgrupp på
+	<a href="/mailinglists.html">distributionslistorna</a>. Koden
+	är <a href="http://github.com/abh/ntppool">publikt tillgänglig</a>.
+        </p>
+
+        <p>
+        Servrar och kapacitet för själva &quot;naven&quot; i systemet
+        tillhandahålls för närvarande av 
+		<a href="http://develooper.com/">Develooper</a>,
+        <a href="http://www.phyber.com/">Phyber Communications</a> och
+        <a href="http://www.yellowbot.com">YellowBot</a>.
+	</p>
+

--- a/docs/ntppool/sv/join.html
+++ b/docs/ntppool/sv/join.html
@@ -1,0 +1,98 @@
+[% page.title = 'Gå med i NTP Pool!'  %]
+
+<div class="block">
+	<h3><a name="join">Hur går jag med i pool.ntp.org?</a></h3>
+	<p>
+	Till att börja med: Tack för att du frågar.  Utnyttandet av 
+	poolen har ökat enormt mycket och enda sättet vi kan se till att 
+	uppgiften att driva en tidsserver inte blir alltför betungande, är
+	att se till antalet deltagande servrar växer.
+	</p>
+
+	<p>
+	Din dator <b>måste ha en statisk IP address</b> och ständig kontakt 
+	med internet.  Det är mycket viktigt att din IP-adress aldrig
+	ändras, eller att det sker extremt sällan (högst någon gång per år).
+	Det krävs inga stora hastigheter. Varje klient skickar bara ett par
+	UDP-paket med några minuters mellanrum, upp till var tjugonde minut.
+	</p>
+
+	<p>
+	För närvarande får varje server mellan 5 och 15 paket per sekund, 
+	med toppar ett par gånger om dagen på 60-120 paket per sekund.
+	Det motsvarar i grova drag 10-15Kbit/s med toppar på
+	50-120Kbit/s.  Projektet värvar ständigt nya tidsservrar så
+	belastningen för varje enskild server bör inte komma att ändras 
+	alltför mycket.  I realiteten, behöver du nog ha en anslutnings på
+	mins 384-512Kbit/s (både upp- och nedströms).
+	</p>
+	<p>
+	Här är några servrar med grafer för trafik och belastning:
+	[% i = 0; FOR server = combust.servers_with_urls; %]
+	   <a href="/scores?ip=[% server.ip %]">[% i=i+1; i %]</a>
+	[% END %]
+	</p>
+
+	<p>
+	Servrar som går med skall inte använda <tt>pool.ntp.org</tt> för sin 
+	egen synkronisering, utan vara konfigurerade med några
+	<a href="http://support.ntp.org/bin/view/Servers/StratumTwoTimeServers">bra servrar</a>
+	manuellt (dessa servrar
+	<b>kan</b> hämtas från poolen, vitsen är att de skall vara statiskt 
+	angivna, i stället för att väljas slumpvis varje gång servern 
+	startar om.  Detta hjälper till att upprätthålla en godtagbar standard.)
+
+	Observera att det inte är nödvändigt att din server hämtar sin tid
+	från en tidsserver i stratum 1 eller 2. Eftersom detta projekt framför 
+	allt handlar om lastdelning, är även servrar i stratum 3
+	eller rentav stratum 4 välkomna.
+	</p>
+
+	<p>
+	Vi har en sida med <a href="/join/configuration.html">rekommenderade
+	inställningar för servrar som ingår i poolen</a>.
+	</p>
+	<p>Slutligen vill jag betona att deltagande i denna pool är ett 
+	<b>långsiktigt åtagande</b>.  Vid behov kan vi plocka bort en server
+	ur poolen när som helst, men på grund av ntp-klienternas beteende
+	så <b>tar det veckor, månader eller till och med FLERA ÅR innan
+	inkommande trafik helt försvinner</b>.
+	</p>
+
+	<p>
+	Om allt detta är ok för dig, logga då in på sidan för 
+	<a href="/manage">hantering av servrar</a> och begär att din server läggs in.
+	Om du har några problem med systemet, skicka då e-post till mig på <a
+	href="mailto:ask@develooper.com">ask@develooper.com</a>.
+	</p>
+	<p>
+	Dessutom ber jag dig att även prenumera på vår
+	<a href="http://news.ntppool.org/atom.xml">blog feed</a>
+	och kanske också <a href="https://lists.ntp.org/listinfo/pool">poolens
+	distributionslista</a>.
+	</p>
+	<p>
+	Det vore trevligt (men är inte nödvändigt) om du kan vidarebefordra
+	web-förfrågningar på port 80 på din server, till projektets officiella
+	hemsida på
+	<tt>http://www.pool.ntp.org</tt>. Om du kör Apache, kan du ordna det så här:
+	</p>
+
+        [% PROCESS tpl/join/virtual_host_example.html %]
+
+	<p>
+	Men, som sagt, det är bara om redan har en web-server. Den officiella webbsidan
+	för projektet anges alltid med 'www' i början, men ibland är människor lata
+	och skriver bara in <tt>pool.ntp.org</tt> i adressfältet, och sedan blir de 
+	förvånade, när de får en helt slumpartade webbsida tillbaka.
+	</p>
+	<p>
+	När servern lagts till i poolen, så övervakas dess tillgänglighet och 
+	tidsnoggrannhet.  Du kan se din servers resultat på 
+	<a href="scores">webb-gränssnittet</a> eller på 
+	<a href="/manage">administrationssidan</a>.
+	</p>
+</div>
+
+
+

--- a/docs/ntppool/sv/join/configuration.html
+++ b/docs/ntppool/sv/join/configuration.html
@@ -1,0 +1,78 @@
+<div class="block">
+
+<h3>Rekommenderad konfiguration för server som ansluts till poolen</h3>
+
+<p>
+<a href="http://support.ntp.org/bin/view/Support/WebHome">Support-delen</a> 
+på <a href="http://support.ntp.org/">support.ntp.org</a> har en hel del
+användbar information.
+</p>
+
+<p>
+Om du bara vill <i>använda</i> poolen, se sidan för <a href="/use.html">användning av poolen</a>.
+</p>
+
+<p>
+Nyhetsgruppen <a
+href="http://groups.google.com/group/comp.protocols.time.ntp">comp.protocols.time.ntp</a>
+är bästa stället att få hjälp med programmet ntpd.
+</p>
+
+<p>
+Här är några punkter som är extra viktiga om du vill ansluta din server till
+NTP-poolen.
+</p>
+
+<h4>Ange cirka 5 servrar</h4>
+
+<p>
+För att fungera korrekt, behöver ntpd prata med minst 3 servrar
+(&quot;Den som har en klocka vet alltid rätt tid. Den som har två klockor 
+är aldrig säker&quot;).
+</p>
+
+<p>
+För servrar i poolen rekommenderar vi att konfigurera för minst 4 och högst
+7 värd-servrar.
+</p>
+
+
+<h4>Ange inte *.pool.ntp.org som server</h4>
+
+<p>
+Ironiskt nog, för att få bästa kvalitet, är det bäst att inte använda
+alias av typen *.pool.ntp.org i din konfiguration när du vill ansluta 
+din server till poolen.
+</p>
+
+<p>
+Poolen blir stabilare och starkare om varje server-operatör
+&quot;handplockar&quot; tids-servrar som ligger nära (nätverksmässigt).
+Wikin på NTP.org har en <a
+href="http://support.ntp.org/bin/view/Servers/WebHome">lista med 
+publika servrar</a>.
+</p>
+
+
+<h4>Använd standard-versionen av ntpd</h4>
+
+<p>
+Vi uppskattar alla att det finns många olika program att välja på, 
+men en betydande andel av frågorna av typen 
+&quot;Det fungerar inte&quot; gäller system med andra program än 
+ntpd.
+</p>
+
+<p>
+Du kan <i>använda</i> poolen med vilket program som helst, som pratar NTP,
+men om du tänker gå med i poolen, rekommenderar vi att du använder
+ <a href="http://support.ntp.org/bin/view/Main/SoftwareDownloads">ntpd</a>.
+</p>
+
+
+<h4>Använd inte LOKAL tidskälla</h4>
+
+<p>Servrar i NTP-Poolen får inte ha LOKAL(LOCAL) tidskälla konfigurerad.</p>
+
+
+</div>

--- a/docs/ntppool/sv/tpl/server/graph_explanation.html
+++ b/docs/ntppool/sv/tpl/server/graph_explanation.html
@@ -1,0 +1,37 @@
+<div id="graph_explanation_box" class="graph_explanation [% graph_explanation ? 'visible' : '' %]">
+
+<h3>Poängkurvan</h3>
+<p>
+Ett par gånger i timmen hämtar pool-systemet tiden från din server
+och jämför med lokal tid.  Poängavdrag görs när en server inte är 
+tillgänglig eller när den går mer än 100ms fel (grovt mätt gentemot
+driftsystemets klocka).  För större tidsavvikelse blir poängavdraget 
+större.
+</p>
+
+<p>
+När poängen minskar, anger bakgrundsfärgen i övre delen hur omfattande
+&quot;driftstoppet&quot; är.  Färgen varierar från blå blue (minimal 
+avvikelse) via gult och orange till röd (servern ligger flera sekunder 
+fel eller svarar inte).  Beroende på hur diagrammet förändras över tiden
+kan du inte direkt utifrån färgkoderna tolka vad som har hänt. Det är 
+mer tänkt som ett verktyg för att trender.  För detaljerad information
+om vad uppföljningssystemet funnit, kan du klicka på länken för CSV.
+
+</p>
+
+<h3>Avvikelsegrafen</h3>
+
+<p>
+Uppföljningssystemet fungerar ungefär som en <a
+href="http://www.ntp.org/ntpfaq/NTP-s-def.htm#AEN1242">SNTP</a> (<a
+href="http://www.eecis.udel.edu/~mills/database/rfc/rfc2030.txt">RFC
+2030</a>) klient, så det har större risk att drabbas av 
+fördröjningar mellan servern och uppföljningssystemet än vad
+en vanlig ntpd klient har.  Därför: Ta inte så hårt på enstaka 
+stora avvikelser, och se inte siffrorna om avvikelser som några 
+exakta mätvärden.
+</p>
+
+</div>
+

--- a/docs/ntppool/sv/use.html
+++ b/docs/ntppool/sv/use.html
@@ -1,0 +1,126 @@
+[% page.title = 'Hur konfigurerar jag NTP för att använda poolen?' %]
+
+<div class="block">
+	<h3><a name="use"></a>Hur använder jag pool.ntp.org?</h3>
+	
+	<p>
+	Om du helt enkelt vill synkronisera din dators tid med nätverket, så är
+	konfigurerings-filen (för programmet ntpd från <a
+	href="http://www.ntp.org">ntp.org distribution</a>, för alla understödda
+	typer av datorsystem - <b>Linux, *BSD, Windows och till och med några mer 
+	exotiska system</b>) riktigt enkel:
+	</p>
+
+<pre class="code">
+driftfile /var/lib/ntp/ntp.drift
+
+server 0.pool.ntp.org
+server 1.pool.ntp.org
+server 2.pool.ntp.org
+server 3.pool.ntp.org</pre>
+	<p>
+	Namnen 0, 1, 2 och 3.pool.ntp.org pekar på några slumpvis valda servrar
+	och ändras varje timme.  Se till att din dators klocka går hyfsat rätt
+	(inom några minuter från 'korrekt' tid). Du skulle kunna använda <tt>ntpdate
+	pool.ntp.org</tt>, eller helt enkelt använda kommandot <tt>date</tt> för att
+	ställa klockan efter ditt armbandsur. Starta sedan <tt>ntpd</tt>, och efter ett tag
+	(Det kan ta så mycket som en halv timme!), kommer kommandot <tt>ntpq -pn</tt> att 
+	svara något i stil med:
+	</p>
+<pre class="code ntpq">
+avbidder:~$ ntpq -p
+     remote           refid      st t when poll reach   delay   offset  jitter
+==============================================================================
++81.6.42.224     193.5.216.14     2 u   68 1024  377  158.995   51.220  50.287
+*217.162.232.173 130.149.17.8     2 u  191 1024  176   79.245    3.589  27.454
+-129.132.57.95   131.188.3.222    3 u  766 1024  377   22.302   -2.928   0.508
+</pre> 
+	<p>
+	Du kommer att se andra IP-adresser, du tilldelas några slumpvis utvalda 
+	tidsservrar. Det centrala är att en av raderna inleds med en asterisk
+	(<tt>*</tt>), vilket innebär att din dator får sin tid via internet och 
+	du behöver inte bry dig i fortsättningen!
+	</p>
+	<p>
+	Eftersom <tt>pool.ntp.org</tt> kommer att ge dig slumpvis valda servrar från
+	hela världen, blir kvaliteten inte idealisk.  Du får ett bättre resultat om
+	du använder din närmaste  <a href="/zone/@">kontinentala zon</a> (T. ex.
+	<a href="/zone/europe">europe</a>,
+	<a href="/zone/north-america">north-america</a>,
+	<a href="/zone/oceania">oceania</a>
+	eller <a href="/zone/asia">asia</a>.pool.ntp.org),
+	eller ännu hellre ditt eget lands zon (exempelvis
+	se.pool.ntp.org för Sverige). I alla dessa zoner, kan du använda prefixen 0,
+	1 eller 2, t.ex. 0.se.pool.ntp.org.  Observera dock att det kanske inte finns
+	någon zon för ditt eget land, eller så kanske den bara har en eller ett par
+	tidsservrar.
+	Om du vet några tidsservrar som ligger riktigt nära dig (mätt i nätverksavstånd
+	med <tt>traceroute</tt> eller <tt>ping</tt>), så får du troligen ännu exaktare tid.
+	</p>
+	<p>
+	Om du har en <b>någorlunda ny version av Windows</b>, så kan du använda systemets
+	inbyggda klient för ntp. När du är inloggad som administratör, skriver du</p>
+<pre class="code">
+w32tm /config /syncfromflags:manual /manualpeerlist:0.pool.ntp.org,1.pool.ntp.org,2.pool.ntp.org,3.pool.ntp.org
+</pre>
+	<p>
+	i ett kommandofönster.  Det fungerarar på Windows 2003 och nyare.  På äldre version
+	av Windows kan du prova
+<pre class="code">
+net time /setsntp:"0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org"
+</pre>
+	Samma resultat kan erhållas om du, som administratör, högerklickar på klockan
+	i aktivitetsfältet och väljer 'Ändra datum/tid' och sedan anger servernamnet
+	under fliken för 'Internettid'.
+	</p>
+
+	<p>
+	Meinberg har porterat <a href="http://www.meinberg.de/english/sw/ntp.htm">ntp daemon till windows</a>.
+	</p>
+
+	<p>
+	Om din Windows-dator ingår i en domän, är det möjligt att du inte har möjlighet att själv ställa din 
+	dators klocka.
+	
+	För mer information om att ställa klockan i Windows, läs <a href="http://technet.microsoft.com/en-us/library/cc773013%28WS.10%29.aspx">How Windows Time Service Works</a>.
+	</p>
+</div>
+
+<div class="block">
+	<h3>Anmärkningar</h3>
+	<p><span class="hook">Om du har en fast IP-adress och hyfsad anslutningshastighet</span> 
+	hastigheten är inte så viktigt, men den behöver vara stabil och inte alltför upptagen), är
+	du välkommen att bidra med din server till vår serverpool. Det drar bara några hundra bytes trafik
+	per sekund, men bidrar till projektets överlevnad.
+	Var vänlig <a href="/join.html">läs inträdes-sidan</a> för ytterligare information.
+	</p>
+	
+	<p><span class="hook">Om din internet-leverantör har en tidsserver</span>, eller om du 
+	kännder till en bra tidsserver i din närhet, då skall du använda den, i stället 
+	för vår lista - det ger troligen en mer exakt tid, samtidigt som det förbrukar mindre
+	nätverksresurser.  Om du bara känner till en tidsserver i din närhet, så kan du givetvis
+	använde den tillsammans med två servrar från pool.ntp.org, t.ex.</p>
+	
+	<p><span class="hook">Någon enstaka gång kan det hända att du tilldelas samma server
+	två gånger</span>. Vanligtvis går det problemet att lösa genom att starta om ntp-servern.
+	Om du använder en lands-zon, så kan det bero på att projektet bara har en enda server
+	från landet i fråga. I så fall är det bättre att använda den närmaste kontinentala zonen
+	i stället.  Du kan <a href="/zone">undersöka zonerna</a> för att se antalet servrar i varje zon.</p>
+	
+	<p><span class="hook">Var hövlig</span>. Många servrar tillhandahålls av frivilliga.
+	Nästan jämt är det frågan om fil- epost- eller webservrar, som dessutom råkar köra ntp.
+	Så nöj dig med tre tidsservrar i din konfiguration och undvik fula knep, såsom
+	<tt>burst</tt> eller <tt>minpoll</tt>. Det enda du kan åstadkomma den vägen är 
+	projektet dör, förr eller senare.</p>
+	
+	<p><span class="hook">Se till att din dator har <i>rätt tidszon</i> inställd</span>.
+	själva ntpd bryr sig inte om tidszoner, utan använder UTC internt.</p>
+	
+	<p><span class="hook">Om du synkroniserar ditt nätverk mot pool.ntp.org</span>, konfigurera
+	då en av dina egna datorer som tidsserver för resten av ditt eget nätverk.
+	(du får läsa på en del, men det är itne svårt. Och så finns ju alltid nyhetsgruppen
+	<a href="news:comp.protocols.time.ntp">comp.protocols.time.ntp newsgroup</a> att tillgå.)</p>
+	
+	<p class="thanks">Slutligen vill jag härmed tacka alla som bidrar med sin egen tid
+	och med sina tidsservrar till detta nätverk.</p>
+</div>

--- a/i18n/sv.po
+++ b/i18n/sv.po
@@ -1,0 +1,119 @@
+msgid ""
+msgstr ""
+"Last-Translator: Tor-Bjorn Fjellner <poedit@fjellner.com>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"Project-Id-Version: ntppool\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Language-Team: T-B Fjellner <poedit@fjellner.com>\n"
+"X-Poedit-Language: Swedish\n"
+"X-Poedit-Country: SWEDEN\n"
+"X-Poedit-SourceCharset: utf-8\n"
+
+msgid "go up"
+msgstr "upp ett steg"
+
+# zone names
+msgid "Africa"
+msgstr "Afrika"
+
+msgid "Asia"
+msgstr "Asien"
+
+msgid "North America"
+msgstr "Nordamerika"
+
+msgid "South America"
+msgstr "Sydamerika"
+
+msgid "Global"
+msgstr "Globalt"
+
+msgid "All Pool Servers"
+msgstr "Alla servrar i poolen"
+
+# navigation
+msgid "Translations"
+msgstr "Översättningar"
+
+# mailinglists.html
+msgid "NTP Pool mailing lists"
+msgstr "Distributionslistor för NTP Pool"
+
+msgid "subscribe"
+msgstr "prenumerera"
+
+msgid "archive"
+msgstr "arkiv"
+
+msgid "Announcement list"
+msgstr "Informationslista"
+
+msgid "Discussion list"
+msgstr "Diskussionslista"
+
+msgid "Development list"
+msgstr "Utvecklarlista"
+
+msgid "announcement_list_description"
+msgstr "Information från NTP Pool, som skickas ut mycket sällan. Alla som driver en server bör prenumerera på informationslistan."
+
+msgid "discussion_list_description"
+msgstr "Server-innehavare (och användare) som vill vare djupare involverade i projektet, kan prenumerera på diskussionslistan.<br/>Allmänna diskussioner om ntp hör givetvis hemma på nyhetsgruppen %1 på Usenet (och på <a href=\"%2\">Google Groups</a>)."
+
+msgid "development_list_description"
+msgstr "Mer tekniskt inriktade (och förhoppningsvis alltid pragmatiska) diskussioner kring den löpande utvecklingen av <a href=\"%1\">koden för ntp pool</a> och <a href=\"%2\">pgeodns</a> sker på listan timekeepers-dev."
+
+# tpl/server.html
+msgid "Back to the front page"
+msgstr "Åter till startsidan"
+
+msgid "Find"
+msgstr "Sök"
+
+msgid "Stats for %1"
+msgstr "Statistik för %1"
+
+msgid "Not active in the pool, monitoring only"
+msgstr "Ej aktiv i poolen, endast uppföljning"
+
+msgid "Zones:"
+msgstr "Zoner:"
+
+msgid "This server is <span class="deletion">scheduled for deletion</span> on %1."
+msgstr "Denna server är <span class=\"deletion\">planerad för borttagning</span> den %1."
+
+msgid "Current score: %1 (only servers with a score higher than %2 are used in the pool)"
+msgstr "Nuvarande poäng: %1 (endast servrar med en poäng på minst %2 används i poolen)"
+
+msgid "What do the graphs mean?"
+msgstr "Vad betyder graferna?"
+
+msgid "CSV log"
+msgstr "Logg för CSV"
+
+# tpl/navigation_sidebar.html
+msgid "News"
+msgstr "Nyheter"
+
+msgid "How do I <i>use</i> pool.ntp.org?"
+msgstr "Hur <i>använder</i> jag pool.ntp.org?"
+
+msgid "How do I <i>join</i> pool.ntp.org?"
+msgstr "Hur <i>går jag med</i> i pool.ntp.org?"
+
+msgid "Information for vendors"
+msgstr "Information för tillverkare"
+
+msgid "The mailing lists"
+msgstr "Våra distributionslistor"
+
+msgid "Additional links"
+msgstr "Extra länkar"
+
+msgid "Can you translate?"
+msgstr "Kan du översätta?"
+


### PR DESCRIPTION
Note: In several places of the html-files, I replaced quotation marks with escaped html entities.
BTW, in the po, there's also one such place, where a couple of quotation marks in the wrong place mess things up and make poedit a bit angry. (look around row 84)
I also noted that you in some places employ gettext to expand a short placeholder into a longer explanation text. It would be clearer for translators if the English /translation/ never differed from the source text.
As an alternative, you could add the intended, long text, as a comment.

Best regards,
Tobi
