### PR TITLE
Missing string "Europe"

### DIFF
--- a/i18n/en.po
+++ b/i18n/en.po
@@ -21,6 +21,9 @@ msgstr "North America"
 msgid "South America"
 msgstr "South America"
 
+msgid "Europe"
+msgstr "Europe"
+
 msgid "Global"
 msgstr "Global"
 


### PR DESCRIPTION
Added missing string to English language file. Although it doesn't matter for the English view itself, it's important to have it because many translators take that file as a base.
