### PR TITLE
Fix typo in german doc

### DIFF
--- a/docs/ntppool/de/use.html
+++ b/docs/ntppool/de/use.html
@@ -61,7 +61,7 @@ remote           refid      st t when poll reach   delay   offset  jitter
   Zeitsynchronisation damit vermutlich besser sein.
  </p>
  <p>
-  Sollten Sie eine neuere Version von <b>Windows</b> einsetzten,
+  Sollten Sie eine neuere Version von <b>Windows</b> einsetzen,
   k&ouml;nnen Sie den NTP-Client nutzen, der in das System integriert
   ist. F&uuml;hren Sie dazu folgendes Kommando als Administrator aus:
  </p>


### PR DESCRIPTION
Fix a small typo in the german usage documentation