### PR TITLE
Improve monitoring script

### DIFF
--- a/monitor
+++ b/monitor
@@ -169,15 +169,13 @@ while (1) {
 	    $Net::NTP::CLIENT_TIME_SEND = $time_then;
 
 	    my %pkt = eval { get_ntp_response($server); };
-            if ($pkt{"Leap Indicator"}) {
-                $status->{leap} = $pkt{"Leap Indicator"};
-            }
 
 	    my $time_now = Time::HiRes::time;
+	    my $root_dist = $pkt{'Root Delay'} / 2 + $pkt{'Root Dispersion'};
 
 	    $status->{ts} = $time_now;
         
-	    if (!$pkt{Stratum} or $!) {
+	    if (!$pkt{Stratum} or $pkt{'Leap Indicator'} == 3 or $root_dist > 1.4) {
 		$status->{no_response} = 1;
 	    }
 	    else {
@@ -188,6 +186,7 @@ while (1) {
 		
 		$status->{offset}  = ($recv_org + $trans_dest) / 2;
 		$status->{stratum} = $pkt{Stratum};
+		$status->{leap} = $pkt{"Leap Indicator"};
 	    }
 	}
 


### PR DESCRIPTION
Check NTP responses if they don't have unsychronized leap and require that the root distance has a reasonable value to ignore servers that would be ignored by some widely used NTP clients (e.g. ntpd using
default tos mindist).

This should affect only a very small number of servers, which for some reason report a large root delay or dispersion, but still have an offset small enough to keep a good score. I think I saw two or three. This check could be useful in case there is a large-scale DoS attack on the pool servers (e.g. exploiting some of the vulnerabilities that were found in ntpd in the past) which would leave them unsynchronized.

This should partially work with net-ntp which doesn't report the fractional part of root dispersion (fixed in abh/net-ntp#2). The check will be just less sensitive, i.e. root dispersion has to reach 2 seconds.