### PR TITLE
Update restrict-default.html to use 'limited' flag

### DIFF
--- a/docs/ntppool/join/configuration/restrict-default.html
+++ b/docs/ntppool/join/configuration/restrict-default.html
@@ -1,4 +1,4 @@
 <pre>
-restrict default kod nomodify notrap nopeer noquery
-restrict -6 default kod nomodify notrap nopeer noquery
+restrict default kod limited nomodify notrap nopeer noquery
+restrict -6 default kod limited nomodify notrap nopeer noquery
 </pre>


### PR DESCRIPTION
`kod` is only usefull with `limited`
The documentation for the `kod` flag states: "If the kod flag is used in a restriction which does not have the limited flag, no KoD responses will result."
See documentation of [Access Control Commands and Options](https://www.eecis.udel.edu/~mills/ntp/html/accopt.html#restrict) for further details.