### PR TITLE
de: updated "Information for vendors"

### DIFF
--- a/i18n/de.po
+++ b/i18n/de.po
@@ -108,7 +108,7 @@ msgid  "How do I <i>join</i> pool.ntp.org?"
 msgstr "Wie kann man sich an pool.ntp.org <i>beteiligen</i>?"
 
 msgid  "Information for vendors"
-msgstr "Informationen f&uuml;r H&auml;ndler"
+msgstr "Informationen f&uuml;r Hersteller"
 
 msgid  "The mailing lists"
 msgstr "E-Mail-Verteiler"


### PR DESCRIPTION
The current german translation for vendor was "Händler" which is a retailer and not the vendor itself.