### PR TITLE
Fix the display name of Chinese language

### DIFF
--- a/lib/NTPPool/Control.pm
+++ b/lib/NTPPool/Control.pm
@@ -39,7 +39,7 @@ our %valid_languages = (
     sv => {name => "Svenska"},
     tr => {name => "Türkçe"},
     uk => {name => "Українська"},
-    zh => {name => "中国（简体）"},
+    zh => {name => "中文（简体）"},
 );
 
 NP::I18N::loc_lang('en');


### PR DESCRIPTION
AFAICS the source of this can be traced back to https://github.com/abh/ntppool/commit/e74a8d18c034e209b8a0f67f3543eaf1fe5e544c, and I assume there is no other reason to use the name of the country instead of the language here.