### PR TITLE
Add all servers to non-numbered zones

### DIFF
--- a/lib/NP/Model/DnsRoot.pm
+++ b/lib/NP/Model/DnsRoot.pm
@@ -101,8 +101,15 @@ sub populate_country_zones {
 
             my $min_non_duplicate_size = 2;
             my $response_records       = 3;
-            my @zones                  = ("", "0.", "1.", "2.", "3.");
+            my @zones                  = ("0.", "1.", "2.", "3.");
             my $zone_count             = scalar @zones;
+
+            # add all servers to the non-numbered "NTP" zone
+            (my $pgeodns_group = "${name}") =~ s/\.$//;
+            push @{$data->{$pgeodns_group}->{a}}, $_ for @$entries;
+            if ($ttl) {
+                $data->{$pgeodns_group}->{ttl} = $ttl;
+            }
 
             $min_non_duplicate_size = int(@$entries / $zone_count)
               if (@$entries / $zone_count > $min_non_duplicate_size);


### PR DESCRIPTION
Instead of splitting servers between non-numbered SNTP and numbered NTP
zones, always duplicate all servers in the SNTP zones. This should
stabilize the rate of requests that servers get as the SNTP zones will
have more servers and they will not be switching between SNTP and NTP
zone.

I'm not sure how much it would actually stabilize the request rate as I don't have my own pool to test it :). It would be an interesting experiment.