### PR TITLE
Improved the Norwegian translations

### DIFF
--- a/docs/ntppool/nb/homepage/intro.html
+++ b/docs/ntppool/nb/homepage/intro.html
@@ -1,0 +1,19 @@
+<p>
+pool.ntp.org-prosjektet er en stort virtuelt klynge av tidstjenere som leverer pålitelige og <a href="use.html">lettbrukelige</a> NTP-tjenere til millioner av klienter.
+</p>
+
+<p>
+Puljen brukes av flere hundre millioner systemer rundt omkring i verden. Det er standard-"tidstjeneren" for de fleste store Linux-distribusjoner og for mange nettverkstilkoblede produkter (Se <a href="vendors.html">informasjon for produsenter</a>).
+</p>
+
+<p>
+På grunn av det store antallet brukere, trenger vi flere tjenere. Dersom du har en tjener med en statisk IP-adresse som alltid er tilgjengelig på internettet, tenk gjerne på om du vil <a href="join.html">legge den til i systemet</a>.
+</p>
+
+<p>
+Prosjektet vedlikeholdes og utvikles av <a href="https://www.askask.com/">Ask Bjørn Hansen</a> og en stor gruppe med bidragsytere på <a href="/mailinglists.html">meldingslistene</a>. Kildekoden til systemet er <a href="https://github.com/abh/ntppool">tilgjengelig</a>.
+</p>
+
+<p>
+Betjenening og båndbredde til sentraltjenerene blir levert av <a href="https://develooper.com/">Develooper</a> and <a href="http://www.phyber.com/">Phyber Communications</a>.
+</p>

--- a/docs/ntppool/nb/join.html
+++ b/docs/ntppool/nb/join.html
@@ -36,7 +36,7 @@
   men de burde sette opp noen <a href="https://support.ntp.org/bin/view/Servers/StratumTwoTimeServers">gode tjenere</a> manuelt (disse tjenerene
 	<b>kan</b> bli valgt fra puljen. Poenget er at de blir valgt statisk i stedet
   for å bli tilfeldig tilegnet ved hver tjeneromstart. Dette vil hjelpe til
-  med å levere en akseptable tjenestekvalitet.
+  med å levere en akseptable tjenestekvalitet.)
 
 	Bemerk at det ikke er påkrevd at tjeneren din er en Stratum 1- eller 2-tjener -
   ettersom dette prosjektet stort sett handler om belastningsfordeling,

--- a/docs/ntppool/nb/join.html
+++ b/docs/ntppool/nb/join.html
@@ -1,0 +1,86 @@
+[% page.title = 'Bli med i NTP-puljen!'  %]
+
+<div class="block">
+	<h3><a name="join">Hvordan blir jeg med i pool.ntp.org?</a></h3>
+	<p>
+	Først og fremst: Takk for interessen din. Bruken av puljen har vokst noe voldsomt,
+  og den eneste måten vi kan gjøre det lett for alle å drifte en puljetjener er å
+  også øke antallet tjenere som deltar.
+	</p>
+
+	<p>
+	Datamaskinen din <b>må ha en statisk IP-adresse</b> og en permanent
+	internettilkobling. Det er veldig viktig at IP-adressen din ikke blir
+  endret på, eller at den kun veldig sjeldent blir det (La oss si én gang
+  i året eller sjeldnere). Den påkrevde båndbredden er relativt lav. Hver
+  klient vil kun sende et par UDP-pakker hver 2.-20. minutt
+	</p>
+
+	<p>
+	For øyeblikket mottar de fleste tjenere mellom 5-15 NTP-pakker i sekundet,
+  med toppunkter et par ganger om dagen på 60-120 pakker per sekund. Dette
+  tilsvarer røft sett 10-15Kb/s med toppunkter på 50-120Kb/s. Prosjektet
+  mottar stadig flere tidstjenere, så belastningen vil nok ikke øke
+  dramatisk for hver tjener. I korte trekk, trenger du nok minst 384-512Kb/s
+  båndbredde (både inn- og utgående).
+	</p>
+	<p>
+	Her er noen tjenere med trafikk-/belastnings-grafer:
+	[% i = 0; FOR server = combust.servers_with_urls; %]
+	   <a href="/scores?ip=[% server.ip %]">[% i=i+1; i %]</a>
+	[% END %]
+	</p>
+
+	<p>
+	Tjenerne som blir med burde ikke bruke <tt>pool.ntp.org</tt> som sin(e) oppstrømstjener(e),
+  men de burde sette opp noen <a href="https://support.ntp.org/bin/view/Servers/StratumTwoTimeServers">gode tjenere</a> manuelt (disse tjenerene
+	<b>kan</b> bli valgt fra puljen. Poenget er at de blir valgt statisk i stedet
+  for å bli tilfeldig tilegnet ved hver tjeneromstart. Dette vil hjelpe til
+  med å levere en akseptable tjenestekvalitet.
+
+	Bemerk at det ikke er påkrevd at tjeneren din er en Stratum 1- eller 2-tjener -
+  ettersom dette prosjektet stort sett handler om belastningsfordeling,
+  er det ikke noen grunn til at en Stratum 3- eller 4-tjener ikke skulle kunne bli med.
+	</p>
+
+	<p>
+	Vi har en side med <a href="/join/configuration.html">oppsettsanbefalinger for tjenere som skal bli med i puljen</a>.
+	</p>
+	<p>Til slutt, vil jeg få frem at å bli med i puljen er en <b>langtidsforpliktelse</b>.
+  Vi vil gladelig ta deg ut av puljen igjen dersom du skulle ønske det, men på
+  grunn av måten NTP-tjenere opererer, <b>kan det ta uker,
+  måneder, eller til og med ÅR før trafikken opphører helt.</b>.
+	</p>
+
+	<p>
+	Dersom alt dette er i orden for deg, logg på
+	<a href="/manage">tjenerbehandlingssiden</a> og be om å få tjeneren din lagt til.
+	Dersom du har noen problemer med systemet, send meg en E-post på <a
+	href="mailto:ask@develooper.com">ask@develooper.com</a>.
+	</p>
+	<p>
+	Jeg ber også om at du abonnerer på
+  <a href="https://news.ntppool.org/atom.xml">nettloggstrømmen</a>
+	og kanskje også til
+	<a href="https://lists.ntp.org/listinfo/pool">puljemeldingslisten</a>.
+	</p>
+	<p>
+	Det hadde vært hyggelig (men ikke påkrevd) om du kunne omdirigert nettforespørsler
+  til port 80 på tidstjeneren din til prosjektets offisielle nettside hos
+	<tt>http://www.pool.ntp.org</tt>. Dersom du kjører Apache, kan du gjøre dette med::
+	</p>
+
+        [% PROCESS tpl/join/virtual_host_example.html %]
+
+	<p>
+	Jeg sier nok en gang at dette kun er dersom du uansett drifter en nettjener. Prosjektets
+  offisielle nettside vil alltid starte med 'www' - men noen ganger skriver folk inn
+  <tt>pool.ntp.org</tt> og blir overrasket over å komme til en tilfeldig nettside.
+	</p>
+	<p>
+	Når tjeneren har blitt lagt til i puljen, blir den konstant holdt øye med for
+  tilgjengelighet og presisjon. Du kan se ytelsen til tjeneren din gjennom
+  <a href="scores">nettgrensesnittet</a> eller
+  <a href="/manage">behandlingssiden</a>.
+	</p>
+</div>

--- a/docs/ntppool/nb/join/configuration.html
+++ b/docs/ntppool/nb/join/configuration.html
@@ -1,0 +1,99 @@
+<div class="block">
+
+<h3>Oppsettsanbefalinger for tjenere som vil bli med i puljen</h3>
+
+<p>
+<a href="http://support.ntp.org/bin/view/Support/WebHome">Brukerstøtteseksjonen</a>
+på <a href="http://support.ntp.org/">support.ntp.org</a> har massevis
+av nyttig informasjon.
+</p>
+
+<p>
+Hvis du bare vil <i>bruke</i> puljen, gå til <a href="/use.html">puljebrukssiden</a>.
+</p>
+
+<p>
+<a href="https://groups.google.com/group/comp.protocols.time.ntp">comp.protocols.time.ntp</a>-nyhetsgruppen
+er det beste stedet å få hjelp med ntpd-programvaren.
+</p>
+
+<p>
+Nedenfor er noen spesielt viktige ting hvis du vil bli med i NTP-puljen
+med tjeneren din.
+</p>
+
+<p>Internet Engineering Task Force har publisert er utkast om 
+<a href="https://tools.ietf.org/html/draft-ietf-ntp-bcp">
+skikk og bruk for Network Time Protocol</a> som vi anbefaler.</p>
+
+<h4 id="management-queries">Behandlingsforespørsler</h4>
+
+<p>Sørg for at standardoppsettet ikke tillater "behandlingsforespørsler". For ntpd gjøres dette ved å
+legge til "noquery"-innstillingene til de forvalgte "restrict"-linjene, for eksempel:</p>
+
+[% INCLUDE "join/configuration/restrict-default.html" %]
+
+<p>For å tillate at kommandoer som "ntpq -c pe" skal virke fra localhost, kan du legge til:</p>
+
+[% INCLUDE "join/configuration/restrict-localhost.html" %]
+
+<h4>Sett opp omkring 5 tjenere</h4>
+
+<p>
+For at det skal virke riktig, må ntpd snakke med minst 3 tjenere («En mann med
+en klokke vet hva klokken er. En mann med to klokker er aldri sikker»).
+</p>
+
+<p>
+For tjenere i puljen, anbefaler vi å sette ikke mindre enn 4 og ikke mere enn
+7 tjenere.
+</p>
+
+
+<h4>Ikke bruk *.pool.ntp.org-tjenere</h4>
+
+<p>
+Ironisk nok, for å sikre at puljetjenesten er så bra som den kan få blitt, burde du
+ikke bruke *.pool.ntp.org-aliaser i oppsettet ditt når du vil legge til tjeneren
+din i puljen.
+</p>
+
+<p>
+For å sikre stødigheten til puljen, er det best om alle puljeoperatører
+"håndvelger" gode lokale (nettverksmessig) tidstjenere.
+NTP.org-wikien har en <a
+href="https://support.ntp.org/bin/view/Servers/WebHome">liste over
+offentlige tjenere</a>.
+</p>
+
+
+<h4>Bruk det vanlige ntpd-programmet</h4>
+
+<p>
+Vi støtter programvarevariasjon fullt og helt, men en betydelig andel av
+"Det virker ikke"-spørsmålene vi får inn dreier seg om programvare som
+ikke er ntpd.
+</p>
+
+<p>
+Du kan <i>bruke</i> puljen til ethvert program som forstår NTP, men dersom
+du vil bli med i puljen, anbefaler vi at du bruker
+<a href="https://support.ntp.org/bin/view/Main/SoftwareDownloads">ntpd</a>.
+</p>
+
+
+<h4>Ikke bruke den LOKALE klokkedriveren</h4>
+
+<p>Tjenere i NTP-puljen burde ikke ha satt opp den LOKALE klokkedriveren.</p>
+
+<h4>Vær oppmerksom på PTR DNS-forespørsler</h4>
+
+<p>Noen tjeneroperatører har meldt ifra om at noen av NTP-brukeren (eller
+brannmurprogrammene deres) utfører en "reversert DNS"-forespørsel (PTR)
+etter IP-adressen til NTP-tjeneren. Bemerk at dette kan få antallet
+forespørsler til å stige. Å øke "levetiden" til disse loggene er anbefalt dersom
+antallet DNS-forespørsler er en bekymring, og vil generelt gjøre antallet
+forespørsler ganske lite.
+</p>
+
+</div>

--- a/i18n/nb.po
+++ b/i18n/nb.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Last-Translator: Daniel Aleksandersen <code@daniel.priv.no>\n"
+"Last-Translator: Imre Kristoffer Eilertsen <imreeil42@gmail.com>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -24,25 +24,62 @@ msgstr "Sør-Amerika"
 msgid "Europe"
 msgstr "Europa"
 
+msgid "Oceania"
+msgstr "Oseania"
+
 msgid "Global"
 msgstr "Globalt"
 
 msgid "All Pool Servers"
-msgstr "Alle Puljetjenere"
+msgstr "Alle puljetjenere"
 
 # navigation
 msgid "Translations"
 msgstr "Oversettelser"
 
+# index.html
+msgid  "Introduction"
+msgstr "Introduksjon"
+
+msgid  "Active Servers"
+msgstr "Aktive tjenere"
+
+msgid  "Links"
+msgstr "Lenker"
+
+msgid  "Terms of service"
+msgstr "Bruksvilkår"
+
+msgid  "Subscribe in a reader"
+msgstr "Abonner i en RSS-leser"
+
+msgid  "Older news"
+msgstr "Eldre nyheter"
+
 # mailinglists.html
 msgid  "NTP Pool mailing lists"
-msgstr "NTP Pulje epostlister"
+msgstr "NTP-pulje-E-postlister"
 
 msgid  "subscribe"
 msgstr "abonner"
 
 msgid  "archive"
 msgstr "arkiv"
+
+msgid  "NTP Pool Forum"
+msgstr "NTP-puljeforum"
+
+msgid  "News site"
+msgstr "Nyhetsside"
+
+msgid  "Development"
+msgstr "Utvikling"
+
+msgid  "forum_description"
+msgstr "Spørsmål (og svar) om NTP-puljen, forslag til forbedringer, og temaer relatert til tidtaking og å drifte NTP-tjenere."
+
+msgid  "news_description"
+msgstr "Annonseringer og nyheter blir lagt ut på nyhetssiden eller i forumet."
 
 msgid  "Announcement list"
 msgstr "Liste for kunngjøringer"
@@ -70,7 +107,7 @@ msgid  "Find"
 msgstr "Finn"
 
 msgid  "Stats for %1"
-msgstr "Statestikk for %1"
+msgstr "Statistikk for %1"
 
 msgid  "Not active in the pool, monitoring only"
 msgstr "Ikke aktiv i puljen, blir kun overvåket"
@@ -104,10 +141,10 @@ msgid  "Information for vendors"
 msgstr "Informasjon for leverandører"
 
 msgid  "The mailing lists"
-msgstr "Epostlistene"
+msgstr "E-postlistene"
 
 msgid  "Additional links"
-msgstr "Yttligere lenker"
+msgstr "Ytterligere lenker"
 
 msgid  "Can you translate?"
 msgstr "Kan du oversette?"

--- a/i18n/no.po
+++ b/i18n/no.po
@@ -31,7 +31,7 @@ msgid "Global"
 msgstr "Global"
 
 msgid "All Pool Servers"
-msgstr "Alle Puljetenarar"
+msgstr "Alle puljetenarar"
 
 # navigation
 msgid "Translations"

--- a/i18n/no.po
+++ b/i18n/no.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Last-Translator: Nils Jarle Haugen <nils@gaupne.net>\n"
+"Last-Translator: Imre Kristoffer Eilertsen <imreeil42@gmail.com>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/i18n/no.po
+++ b/i18n/no.po
@@ -39,10 +39,10 @@ msgstr "Omsetjingar"
 
 # index.html
 msgid  "Introduction"
-msgstr "Instroduksjon"
+msgstr "Introduksjon"
 
 msgid  "Active Servers"
-msgstr "AAktive tenarar"
+msgstr "Aktive tenarar"
 
 msgid  "Links"
 msgstr "Lenkjer"
@@ -79,7 +79,7 @@ msgid  "announcement_list_description"
 msgstr "Kortfatta og presise kunngjeringar med nyhende om NTP Pool-prosjektet. Alle tenar-administratorar bør abonnere på denne lista."
 
 msgid  "discussion_list_description"
-msgstr "Tenaradministatorar (og gjerne brukarar) som ynskjer å involvere seg meir i prosjektet kan abonnere til denne diskusjonslista. <br/> Generelle diskusjonar om ntp bør takast på %1 Usenet nyhendegruppa (og på <a href=\"%2\">Google Groups</a>)."
+msgstr "Tenaradministatorar (og gjerne brukarar) som ynskjer å involvere seg meir i prosjektet kan abonnere til denne diskusjonslista. <br/> Generelle diskusjonar om NTP bør takast på %1 Usenet-nyhendegruppa (og på <a href=\"%2\">Google Groups</a>)."
 
 msgid  "development_list_description"
 msgstr "Meir tekniske (og helst sett løysingsorienterte) diskusjonar om aktuell utvikling innan<a href=\"%1\">prosjektkoden</a> og <a href=\"%2\">pgeodns</a> skjer på timekeepers-dev diskusjonslista."


### PR DESCRIPTION
In particular, I added some strings that were missing from `nb.po`, in the hopes of alleviating the fact that the Norwegian Bokmål translation is not actually being used on https://www.ntppool.org at the time of writing, thus ensuring that whoever knows how to make that translation go live can do that.