### PR TITLE
Change "server" command to "pool"

### DIFF
--- a/docs/ntppool/use/sample-config.html
+++ b/docs/ntppool/use/sample-config.html
@@ -1,8 +1,8 @@
 <pre class="code">
 driftfile /var/lib/ntp/ntp.drift
 
-server 0.pool.ntp.org
-server 1.pool.ntp.org
-server 2.pool.ntp.org
-server 3.pool.ntp.org
+pool 0.pool.ntp.org
+pool 1.pool.ntp.org
+pool 2.pool.ntp.org
+pool 3.pool.ntp.org
 </pre>


### PR DESCRIPTION
Per discussion in https://community.ntppool.org/t/vendor-zone-s-not-resolving/1408/8, so that hosts re-query the pool for a new pool server when an existing pool server becomes unreachable.  Support in ntpd looks to have been added in v4.2.6 which was released in late 2016.