### PR TITLE
Fix support email mailto

### DIFF
--- a/docs/manage/tpl/manage.html
+++ b/docs/manage/tpl/manage.html
@@ -40,7 +40,7 @@
             </p>
 
             <p>
-                To change other server information, email <a href="mailto:[% " support" | email %]">[% "support" | email
+                To change other server information, email <a href="mailto:[% "support" | email %]">[% "support" | email
                     %]</a>.
             </p>
         </div>

--- a/docs/manage/tpl/manage/add.html
+++ b/docs/manage/tpl/manage/add.html
@@ -66,7 +66,7 @@
                 [% END %]
             </select><br>
             If the country of your server isn't listed, please email
-            <a href="mailto:[% " support" | email %]">[% "support" | email %]</a>.
+            <a href="mailto:[% "support" | email %]">[% "support" | email %]</a>.
 
         </div>
     </p>


### PR DESCRIPTION
https://manage.ntppool.org/manage/servers has this snippet in the HTML (some dashes added/removed):

`To change other server information, email <a href="mailto:a-s-k@ntppool.org">serverownerhelp@ntppool.org</a>.`

I believe this untested change would make the mailto link point to serverownerhelp@ntppool.org as well.