### PR TITLE
Add ipv6 servers to all zones

### DIFF
--- a/lib/NP/Model/DnsRoot.pm
+++ b/lib/NP/Model/DnsRoot.pm
@@ -110,72 +110,72 @@ sub populate_country_zones {
         $name = ''       if $name eq '@';
         $name = "$name." if $name;
 
-        if (my $entries = $zone->active_servers('v4')) {
+        my @ip_versions = ('v4', 'v6');
+        my %record_types = (v4 => 'a',
+                            v6 => 'aaaa');
 
-            my $min_non_duplicate_size = 2;
-            my $response_records       = 3;
-            my @zones                  = ("0.", "1.", "2.", "3.");
-            my $zone_count             = scalar @zones;
+        foreach my $ip_version (@ip_versions) {
 
-            # add all servers to the non-numbered "NTP" zone
-            (my $pgeodns_group = "${name}") =~ s/\.$//;
-            push @{$data->{$pgeodns_group}->{a}}, $_ for @$entries;
-            if ($ttl) {
-                $data->{$pgeodns_group}->{ttl} = $ttl;
-            }
+            my $record_type = $record_types{$ip_version};
 
-            $min_non_duplicate_size = int(@$entries / $zone_count)
-              if (@$entries / $zone_count > $min_non_duplicate_size);
+            if (my $entries = $zone->active_servers($ip_version)) {
 
-            # print $fh "# " . scalar @$entries . " active servers in ", $zone->name, "\n";
+                my $min_non_duplicate_size = 2;
+                my $response_records       = 3;
+                my @zones                  = ("0.", "1.", "2.", "3.");
+                my $zone_count             = scalar @zones;
 
-            if ($#$entries < ($min_non_duplicate_size * $zone_count - 1)) {
+                # add all servers to the non-numbered "NTP" zone
+                (my $pgeodns_group = "${name}") =~ s/\.$//;
+                push @{$data->{$pgeodns_group}->{$record_type}}, $_ for @$entries;
+                if ($ttl) {
+                    $data->{$pgeodns_group}->{ttl} = $ttl;
+                }
 
-                # possible duplicates, not enough servers
-                foreach my $z (@zones) {
-                    (my $pgeodns_group = "$z${name}") =~ s/\.$//;
+                $min_non_duplicate_size = int(@$entries / $zone_count)
+                if (@$entries / $zone_count > $min_non_duplicate_size);
 
-                    # already has an alias, so don't add more data
-                    if ($data->{$pgeodns_group}->{alias}) {
-                        next;
+                # print $fh "# " . scalar @$entries . " active servers in ", $zone->name, "\n";
+
+                if ($#$entries < ($min_non_duplicate_size * $zone_count - 1)) {
+
+                    # possible duplicates, not enough servers
+                    foreach my $z (@zones) {
+                        (my $pgeodns_group = "$z${name}") =~ s/\.$//;
+
+                        # already has an alias, so don't add more data
+                        if ($data->{$pgeodns_group}->{alias}) {
+                            next;
+                        }
+
+                        $data->{$pgeodns_group}->{$record_type} = [];
+                        if ($ttl) {
+                            $data->{$pgeodns_group}->{ttl} = $ttl;
+                        }
+                        @$entries = shuffle(@$entries);
+                        foreach my $e (@$entries) {
+                            push @{$data->{$pgeodns_group}->{$record_type}}, $e;
+                        }
                     }
+                }
+                else {
 
-                    $data->{$pgeodns_group}->{a} = [];
-                    if ($ttl) {
-                        $data->{$pgeodns_group}->{ttl} = $ttl;
-                    }
+                    # 'big' zone without duplicates
                     @$entries = shuffle(@$entries);
-                    foreach my $e (@$entries) {
-                        push @{$data->{$pgeodns_group}->{a}}, $e;
-                    }
-                }
-            }
-            else {
-
-                # 'big' zone without duplicates
-                @$entries = shuffle(@$entries);
-                foreach my $z (@zones) {
-                    (my $pgeodns_group = "$z${name}") =~ s/\.$//;
-                    if ($ttl) {
-                        $data->{$pgeodns_group}->{ttl} = $ttl;
-                    }
-                    $data->{$pgeodns_group}->{a} = [];
-                    for (my $i = 0; $i < $min_non_duplicate_size; $i++) {
-                        my $e = shift @$entries;
-                        push @{$data->{$pgeodns_group}->{a}}, $e;
+                    foreach my $z (@zones) {
+                        (my $pgeodns_group = "$z${name}") =~ s/\.$//;
+                        if ($ttl) {
+                            $data->{$pgeodns_group}->{ttl} = $ttl;
+                        }
+                        $data->{$pgeodns_group}->{$record_type} = [];
+                        for (my $i = 0; $i < $min_non_duplicate_size; $i++) {
+                            my $e = shift @$entries;
+                            push @{$data->{$pgeodns_group}->{$record_type}}, $e;
+                        }
                     }
                 }
             }
         }
-
-        if (my $entries = $zone->active_servers('v6')) {
-            @$entries = shuffle(@$entries);
-
-            # for now just put all IPv6 servers in the '2' zone
-            (my $pgeodns_group = "2.${name}") =~ s/\.$//;
-            push @{$data->{$pgeodns_group}->{aaaa}}, $_ for @$entries;
-        }
-
     }
 }
 


### PR DESCRIPTION
My proposal to, well, add ipv6 servers to all zones in the pool.

Nothing here is carved in stone and I am looking forward for constructive feedback and discussions about it and possible alternatives.

## Technical description
I parametrized the code that was used to distribute the IPv4 records across the zones. Then I wrote a loop around it to iterate over both Ipv4 and IPv6.
At the end I removed the now obsolete section that put IPv6 records in the 2. zones.

While the change view of Github does not acurately reflect it, only very few lines were actually changed - most just got indented.

I have successfully tested the changes on my pool development instance, albeit with much smaller amounts of servers than the live pool has.

## Reasoning
The wish to enable IPv6 has been discussed at length at various times and spaces, most prominently in [this forum thread](https://community.ntppool.org/t/the-time-has-come-we-must-enable-ipv6-entirely/1968/107).

Both IP versions should be handled without regard to the other one, since IPv4-only and IPv6-only clients exist. Using the same algorithm for both IP versions keeps the code simple and optimizes the distribution of servers in both adress spaces.

## Change impacts
This change will increase the total amount of records contained in an ntppool zone file. Since those files are only generated and transferred sporadically, this won't have much of an impact.

The obvious impact and goal of this change is that pool zones that have so far only returned A records will now start returning AAAA records as well. This will change nothing for IPv4-only clients, and enable using all pool zones for IPv6-only clients. For dual stack clients, this change will increase the number of servers returned from the pool.

## Known discussion points and my take on them
> The IPv4 zone distribution has it's own problems in underserved zones. Enabling IPv6 will extend those problems into the IPv6 space

Since this change will increase the number of servers that are dealt out at the "default" unnumbered zones, this change will hopefully actually help to mitigate this. A better distribution algorithm is a good idea, but at least in my opinion an independent change from enabling IPv6. Waiting for a new distribution approach is, from my point of view, not necessary. Not having IPv6 has shown to have its own problems, and I think that overall this PR will solve more problems than it creates.

> Some vendor zones expect only A records on certain zones.

This is a curios topic. From my understanding, a properly configured client in a properly configured network should either be able to use DNS records requested by it, or discard them. So to introduce AAAA records should only negatively impact clients and networks that are arguably already broken.
On the other hand, the pool is a fixture in the world of internet services and serves millions of clients that don't even know about it, so changes with the potential to break things should always be considered carefully.
In this special case, it would be interesting to know more about the background behind this topic, and if it is more a theoretical possibility or an actual hard requirement. If backwards compatibility for vendor zones is non-negotiable, I have outlined a plan for that [here](https://community.ntppool.org/t/the-time-has-come-we-must-enable-ipv6-entirely/1968/106?u=sebhoster)

## Closing thoughts
As stated above, I am open to constructive feedback and discussions about this approach. Many people, including me, are looking forward to a fully IPv6-enabled NTP Pool. While this PR is a quite simple and straightforward attempt, I am open to commit the time and incorporate changes or to implement a different approach should the discussion lead there.