### PR TITLE
Fix incorrect closing tag

### DIFF
--- a/docs/ntppool/en/use.html
+++ b/docs/ntppool/en/use.html
@@ -10,7 +10,7 @@
 	[% INCLUDE "ntppool/use/sample-config.html" %]
 
 	<p>
-	The 0, 1, 2 and <code>3.pool.ntp.org<code/> names point to a random set of servers that will
+	The 0, 1, 2 and <code>3.pool.ntp.org</code> names point to a random set of servers that will
 	change every hour.  Make sure your computer's clock is set to something
 	sensible (within a few minutes of the 'true' time) - you could use <code>ntpdate
 	pool.ntp.org</code>, or you could just use the <code>date</code> command and set it


### PR DESCRIPTION
Screenshot of issue on [use.html](https://www.ntppool.org/en/use.html):
![Screenshot 2024-10-10 at 16-43-45 pool ntp org How do I setup NTP to use the pool](https://github.com/user-attachments/assets/9e2f6307-7cf6-48cc-8686-3214831f53c7)
