### PR TITLE
Add lower "netspeed" values

### DIFF
--- a/docs/manage/tpl/manage/server.html
+++ b/docs/manage/tpl/manage/server.html
@@ -38,7 +38,7 @@
         <select name="netspeed"
             onchange="NP.update_netspeed('[% server.id %]', this.value, '[% combust.auth_token %]'); return false;">
             <option value="">Set connection speed</option>
-            [% speeds = [server.netspeed, 0, 512, 1500, 3000, 6000, 12000, 25000, 50000, 100000, 250000, 500000, 1000000, 1500000, 2000000, 3000000]; %]
+            [% speeds = [server.netspeed, 0, 5, 10, 50, 100, 250, 512, 1500, 3000, 6000, 12000, 25000, 50000, 100000, 250000, 500000, 1000000, 1500000, 2000000, 3000000]; %]
             [% FOR speed = speeds.nsort.unique; %] <option
                 value="[% speed %]">[% combust.netspeed_human(speed) %]</option>
             [%- END %]


### PR DESCRIPTION
To make it easier for servers to join "underserved" zones, i.e., zones where the client/server ratio is such that less powerful servers (or network infrastructure/traffic quota/available bandwidth/...) would easily get overwhelmed even at the current lowest setting of "512 Kbit".

Recent example: https://community.ntppool.org/t/the-issue-of-ntp-requests-exceeding-bandwidth-load/3588

But also, e.g., https://www.ntppool.org/scores/47.236.162.36/, which is in monitoring mode only because it is limited to roughly 1Mbit/s of bandwidth, which would be easily exceeded in this zone even at the "512 Kbit" netspeed setting.

The proposed values are obviously somewhat arbitrary, and different values could be chosen instead. Except the lowest value should hopefully cover the first example above, and the highest new value should hopefully cover the second example. And then some values in between.

Obviously, those values don't make much sense in zones that are not underserved, and achieving the actually intended share will work less well the smaller the netspeed value (in relation to the sum of netspeeds configured for the zone). 

And even in underserved zones, lower values might still result in traffic peaks that may overwhelm the server/infrastructure/traffic quota/available bandwidth/... But that would hopefully then be short peaks only, and allow at least _some more_ servers to join an underserved zone (though not all, as there will still be servers that still will be challenged by the traffic load/traffic load peaks).

A refined approach could be to tailor the netspeeds offered to the zone a server resides in. I.e., underserved zones would have additional lower netspeeds available, better served zones will have just the current set. A wide range of how granular this could be is conceivable. However, to start, maybe keep it simple, and make this additional set of netspeeds conditional on the continent zone (vs. individual country zones) only, e.g., zones in Asia are typically underserved, maybe also Africa and South America.

Unfortunately, I don't understand enough about how the website works to make a more specific proposal for the latter refinement myself.