### PR TITLE
graphs: Make coloring consistent with scoring

### DIFF
--- a/docs/shared/static/js/graphs.server.js
+++ b/docs/shared/static/js/graphs.server.js
@@ -185,10 +185,10 @@ function server_chart(div, data, options) {
             var offset = d.offset;
 
             if (offset < 0) { offset = offset * -1; }
-            if (offset < 0.050) {
+            if (offset < 0.075) {
                 return "green";
             }
-            else if (offset < 0.100) {
+            else if (offset < 0.250) {
                 return "orange";
             }
             else {


### PR DESCRIPTION
## Why was this changed

The [scoring system](https://github.com/ntppool/monitor/blob/29c316960e7027eb4cd02ef20fee6db5eaf17b4e/scorer/statusscore/statusscore.go#L67) currently has four "ranges" depending on the time offset between the monitored server and the monitor:
- <75ms : The server is considered "good" and receives one point in the scoring, improving its reputation
- 75 - 250ms: The server is still considered as viable, but not as good. In this range, a sliding scale is applied, granting a lesser score for a higher offset. At 250ms offset, 0 points are granted.
- \>250ms: The same sliding scale is still applied, but returns negative values, resulting in a loss of reputation for the server. The higher the offset, the higher the loss. At 750ms, the scale reaches -2 points.
- \>750ms: The monitor returns -2 points
- \>3000ms: The monitor returns -4 points. Additionally, the server reputation is capped at -20 points, removing it from the pool immediately if it had been above 10 points before.

![grafik](https://github.com/user-attachments/assets/a3c465d6-5b84-488c-b1b1-b936385f084a)

The colouring scheme in the graphs of the management sites had three "ranges":
- <50ms : Green
- 50 - 100ms : Orange
- \>100ms : Red

My suggestion is to unify both systems. This increases transparency for pool operators and users. The graph already is the direct feedback what the monitoring system thinks about the server in terms of current reputation. Adding in the colouring scheme adds the layer of how the reputation is currently changing.

To keep the current traffic light scheme with red-yellow-green, I've decided to map everything in the negative point range to "red" since this indicates that the server will lose points and drop out of the NTP Pool eventually. The yellow range is adjusted to the slow gain range where the server is generally considered viable, but gets a penalty for inaccuracy. Indicating this with yellow should also give the server operator the feedback that the accuracy of the server should be improved. The range where the server gets the full score is indicated in green.

## What was changed

I simply edited the threshold that determine the colors.

## Impact

Expected advantages have been outlined above.
Since this is a purely visual change, I do not expect any negative side effects.

I look forward to constructive feedback and reviews.