### PR TITLE
Change graph score offset thresholds to match values from monitor scorer

### DIFF
--- a/client/src/utils/dom-utils.ts
+++ b/client/src/utils/dom-utils.ts
@@ -53,9 +53,10 @@ export const COLORS: ChartColors = {
 
 // Threshold values for chart display
 export const THRESHOLDS: ChartThresholds = {
+  // values taken from https://github.com/ntppool/monitor/blob/main/scorer/statusscore/statusscore.go#L72
   offset: {
-    good: 0.05,
-    warning: 0.2,
+    good: 0.025,
+    warning: 0.100,
     max: 2,
     min: -2
   },


### PR DESCRIPTION
The threshold values for point deduction and minimum points to be included in the pool have been changed. Goal of this PR is to match the color coding of the offset charts on the pool management page to the values used in the production monitoring system:

- < 25ms: Full points (green)
- 25-100ms: Point deduction, but still viable for the pool (orange)
- \>100ms: Point deduction, server score will settle below 10 points and the server will not be included in the pool (red)

Full reasoning can be found in my earlier PR https://github.com/abh/ntppool/pull/249 which is superseded by this one.

Part of https://github.com/abh/ntppool/issues/251