### PR TITLE
Add Kiswahili (sw) translation

### DIFF
--- a/docs/ntppool/sw/homepage/intro.html
+++ b/docs/ntppool/sw/homepage/intro.html
@@ -1,0 +1,19 @@
+<p>
+Mradi wa pool.ntp.org ni kundi kubwa la seva za saa zinazotoa huduma ya NTP inayotegemewa na <a href="use.html">rahisi kutumia</a> kwa mamilioni ya wateja.
+</p>
+
+<p>
+Pool inatumika na mamia ya mamilioni ya mifumo duniani kote. Ni "seva ya saa" chaguomsingi kwa mifumo mingi mikubwa ya Linux na vifaa vingi vya mtandao (tazama <a href="vendors.html">taarifa kwa watengenezaji</a>).
+</p>
+
+<p>
+Kwa sababu ya idadi kubwa ya watumiaji tunahitaji seva zaidi. Ikiwa una seva yenye anwani ya IP thabiti inayopatikana kila wakati kwenye mtandao, tafadhali fikiria <a href="join.html">kuiongeza kwenye mfumo</a>.
+</p>
+
+<p>
+Mradi huu unasimamiwa na kuendelezwa na <a href="https://www.askask.com/">Ask Bjørn Hansen</a> na kundi zuri la wachangiaji kwenye <a href="/mailinglists.html">jukwaa la jumuiya ya mradi</a>. Msimbo wa chanzo wa mfumo <a href="https://github.com/abh/ntppool">unapatikana</a>.
+</p>
+
+<p>
+Upangishaji na kipimo data kwa seva za "kitovu" vinatolewa na <a href="https://www.equinix.com/">Equinix</a> na <a href="https://www.netactuate.com/">Netactuate</a>.
+</p>

--- a/docs/ntppool/sw/join.html
+++ b/docs/ntppool/sw/join.html
@@ -1,0 +1,80 @@
+[% page.title = 'Jiunge na NTP Pool!'  %]
+
+<div class="block">
+	<h3><a name="join">Ninawezaje kujiunga na pool.ntp.org?</a></h3>
+	<p>
+	Kwanza: Asante kwa kupendezwa kwako. Matumizi ya pool yameongezeka
+	sana, na njia pekee tunaweza kuifanya iwe rahisi kwa kila mtu kuendesha
+	seva ya pool ni pia kuongeza idadi ya seva zinazoshiriki.
+	</p>
+
+	<p>
+	Kompyuta yako <b>lazima iwe na anwani ya IP thabiti</b> na muunganisho
+	wa mtandao wa kudumu. Ni muhimu sana kwamba anwani yako ya IP isibadilishwe
+	au ibadilishwe mara chache sana (sema mara moja kwa mwaka au
+	chini). Kipimo data kinachohitajika ni kidogo sana. Kila mteja
+	atatuma pakiti chache za UDP kila dakika chache hadi kila dakika 20.
+	</p>
+
+	<p>
+	Kwa sasa seva nyingi zinapata pakiti 5-15 za NTP kwa sekunde
+	na vilele vya pakiti 60-120 kwa sekunde mara chache kwa siku.
+	Hii ni sawa na takriban 10-15Kbit/sekunde na
+	vilele vya 50-120Kbit/sekunde. Mradi unapata seva zaidi za saa
+	kwa kuendelea, kwa hivyo mzigo haupaswi kuongezeka sana kwa
+	kila seva. Kwa maneno rahisi, labda unahitaji angalau
+	384-512Kbit ya kipimo data (kinachoingia na kutoka).
+	</p>
+
+	<p>
+	Seva zinazojiunga hazipaswi kuwa na <tt>pool.ntp.org</tt> kama seva yao ya juu,
+	bali zinapaswa kusanidi <a href="https://support.ntp.org/Servers/StratumTwoTimeServers/">seva nzuri</a> kwa mikono. Seva hizo
+	<b>zinaweza</b> kuchaguliwa kutoka kwenye pool. Jambo kuu ni kwamba zinachaguliwa
+	kwa thabiti badala ya kupewa kwa nasibu kutoka kwenye pool kila seva
+	inapoanzishwa upya. Hii itasaidia kutoa ubora unaokubalika wa huduma.
+
+	Kumbuka kwamba si lazima seva yako iwe ya tabaka la 1 au 2
+	- kwa kuwa mradi huu ni zaidi ya kusambaza mzigo, hakuna
+	sababu kwa nini seva ya tabaka la 3 au hata tabaka la 4 isijiunga.
+	</p>
+
+	<p>
+	Tuna ukurasa wenye <a href="/join/configuration.html">mapendekezo ya usanidi kwa seva zinazojiunga na pool</a>.
+	</p>
+	<p>Hatimaye, lazima nisisitize kwamba kujiunga na pool ni <b>ahadi ya muda
+	mrefu</b>. Tutafurahi kukuondoa kwenye pool tena ikiwa hali
+	yako itabadilika, lakini kwa sababu ya jinsi wateja wa NTP wanavyofanya kazi <b>itachukua
+	wiki, miezi au hata MIAKA kabla ya trafiki kupotea kabisa</b>.
+	</p>
+
+	<p>
+	Ikiwa haya yote ni sawa, ingia kwenye
+	ukurasa wa <a href="/manage">usimamizi wa seva</a> na uombe seva yako iongezwe.
+	Ikiwa una tatizo lolote na mfumo, tuma barua pepe kwa <a
+	href="mailto:ask@develooper.com">ask@develooper.com</a>.
+	</p>
+
+	<p>
+	Tafadhali pia jiunge na <a href="[% language_url("/mailinglists.html") %]">jukwaa la jumuiya</a>
+	</p>
+
+	<p>
+	Itakuwa vizuri (lakini si lazima) ikiwa unaweza kuelekeza maombi ya wavuti
+	kwenye bandari ya 80 ya seva yako ya saa kwenye ukurasa rasmi wa mradi katika
+	<tt>https://www.ntppool.org/</tt>. Ikiwa unaendesha Apache, unaweza kufanya hivi kwa:
+	</p>
+
+        [% PROCESS tpl/join/virtual_host_example.html %]
+
+	<p>
+	Tena, hii ni tu ikiwa unaendesha seva ya wavuti tayari. Ukurasa rasmi wa mradi
+	utapewa daima na 'www' mwanzoni - lakini wakati mwingine
+	watu wanaandika <tt>pool.ntp.org</tt> na wanashangaa kupata ukurasa wa wavuti wa nasibu.
+	</p>
+	<p>
+	Mara ikiongezwa kwenye pool, seva inafuatiliwa kila wakati kwa
+        upatikanaji na usahihi. Unaweza kutazama utendaji wa seva yako
+        ukitumia <a href="scores">sehemu ya wavuti</a> au
+        <a href="/manage">ukurasa wa usimamizi</a>.
+	</p>
+</div>

--- a/docs/ntppool/sw/use.html
+++ b/docs/ntppool/sw/use.html
@@ -37,7 +37,7 @@
 	Tafadhali kumbuka pia kwamba mfumo huu kwa sasa unatoa anwani za IPv6 kwa kanda pamoja
 	na anwani za IPv4 ikiwa jina la kanda limeongezwa nambari 2, k.m. <code>2.pool.ntp.org</code>
 	(mradi kuna seva yoyote ya NTP ya IPv6 katika kanda husika). Majina ya kanda ambayo hayajawekwa nambari,
-	au yamewekwa 0, 1 au 3, kwa sasa yanatoa anwani za IPv4 pekee.
+	au yamewekwa 0, 1 au 3, kwa sasa yanatoa anwani za IPv4 pekee.</p>
 	<p>
 	Ikiwa unatumia <b>toleo jipya la Windows</b>, unaweza kutumia mteja wa NTP
 	uliojengwa ndani ya mfumo.</p>

--- a/docs/ntppool/sw/use.html
+++ b/docs/ntppool/sw/use.html
@@ -1,0 +1,115 @@
+[% page.title = 'Jinsi ya kusanidi NTP kutumia pool?' %]
+
+<div class="block">
+	<h3 id="use">Ninawezaje kutumia pool.ntp.org?</h3>
+
+	<p>
+	Ikiwa unataka tu kusawazisha saa ya kompyuta yako na mtandao, faili ya usanidi (kwa programu ya ntpd kutoka <a href="https://www.ntp.org/">ntp.org</a>, kwenye mfumo wowote unaotumika - <b>Linux, *BSD, Windows na hata mifumo mingine ya kipekee</b>) ni rahisi sana:
+	</p>
+
+	[% INCLUDE "ntppool/use/sample-config.html" %]
+
+	<p>
+	Majina 0, 1, 2 na <code>3.pool.ntp.org</code> yanaelekeza kwenye seti ya seva za nasibu ambazo zitabadilika kila saa. Hakikisha saa ya kompyuta yako imesanidiwa kwa kitu kinachofaa (ndani ya dakika chache za saa 'halisi') - unaweza kutumia <code>ntpdate pool.ntp.org</code>, au unaweza kutumia amri ya <code>date</code> na kuisanidi kulingana na saa yako ya mkono. Anzisha ntpd, na baada ya muda (hii inaweza kuchukua hadi nusu saa!), <code>ntpq -pn</code> inapaswa kuonyesha kitu kama:
+	</p>
+
+	[% INCLUDE "ntppool/use/sample-ntpq.html" %]
+
+	<p>
+	Anwani za IP zitakuwa tofauti, kwa sababu umepewa seva za saa za nasibu. Jambo muhimu ni kwamba mojawapo ya mistari inaanza na nyota (<code>*</code>), hii inamaanisha kompyuta yako inapata saa kutoka mtandao - huhitaji kuwa na wasiwasi tena!
+	</p>
+	<p>
+	Kutafuta <code>pool.ntp.org</code> (au <code>0.pool.ntp.org</code>,
+	<code>1.pool.ntp.org</code>, nk) kwa kawaida kutarudisha anwani za IP kwa seva zilizo ndani ya au karibu na nchi yako. Kwa watumiaji wengi hii itatoa matokeo bora.
+	</p>
+
+	<p>Unaweza pia kutumia <a href="/zone/@">kanda za bara</a> (Kwa mfano
+	<a href="/zone/europe">ulaya</a>,
+	<a href="/zone/north-america">amerika-kaskazini</a>,
+	<a href="/zone/oceania">oceania</a>
+	au <code><a href="/zone/asia">asia</a>.pool.ntp.org</code>),
+	na kanda ya nchi (kama
+	<code>ch.pool.ntp.org</code> nchini Uswisi) - kwa kanda hizi zote, unaweza tena kutumia viambishi 0,
+	1, 2, au 3, kama <code>0.ch.pool.ntp.org</code>. Lakini kumbuka, kanda ya nchi
+	huenda haipo kwa nchi yako, au inaweza kuwa na seva moja au mbili tu za saa.
+	</p>
+	<p>
+	Tafadhali kumbuka pia kwamba mfumo huu kwa sasa unatoa anwani za IPv6 kwa kanda pamoja
+	na anwani za IPv4 ikiwa jina la kanda limeongezwa nambari 2, k.m. <code>2.pool.ntp.org</code>
+	(mradi kuna seva yoyote ya NTP ya IPv6 katika kanda husika). Majina ya kanda ambayo hayajawekwa nambari,
+	au yamewekwa 0, 1 au 3, kwa sasa yanatoa anwani za IPv4 pekee.
+	<p>
+	Ikiwa unatumia <b>toleo jipya la Windows</b>, unaweza kutumia mteja wa NTP
+	uliojengwa ndani ya mfumo.</p>
+	<p>Bofya kulia saa kwenye eneo la mfumo na uchague Rekebisha Tarehe/Saa au fungua mipangilio kwa Win+I na ubofye Saa na Lugha -&gt; Tarehe na Saa.
+		Sogea chini na ubofye Muundo wa tarehe, saa, na eneo
+		Sogea chini na ubofye Mipangilio ya ziada ya tarehe, saa na eneo
+		Bofya Tarehe na Saa na Saa ya Mtandao
+		Bofya kitufe cha Badilisha mipangilio. Ingiza <code>pool.ntp.org</code> na ubofye Sasisha sasa.</p>
+	<p>
+		Jaribu kwa kubofya kulia saa kwenye eneo la mfumo na uchague Rekebisha Tarehe/Saa au fungua mipangilio kwa Win+I na ubofye Saa na Lugha -&gt; Tarehe na Saa.
+		Bofya kitufe cha "Sawazisha sasa".
+	</p>
+	<p>
+	Ikiwa mfumo wako wa Windows ni sehemu ya kikoa, huenda usiweze kusasisha saa ya kompyuta yako kwa uhuru.
+
+	Kwa taarifa zaidi kuhusu kusanidi saa kwenye Windows, tazama <a href="https://technet.microsoft.com/en-us/library/cc773013%28WS.10%29.aspx">Jinsi Huduma ya Saa ya Windows Inavyofanya Kazi</a>.
+	</p>
+</div>
+
+<div class="block">
+	<h3 id="notes">Maelezo ya Ziada</h3>
+
+        <p><span class="hook">Fikiria kama NTP Pool inafaa kwa matumizi yako</span>. Ikiwa biashara, shirika au maisha ya binadamu
+        yanategemea kuwa na saa sahihi au yanaweza kuathiriwa na kuwa na saa isiyosahihi,
+        hupaswi "kuipata tu kutoka mtandao". NTP
+        Pool kwa ujumla ni ya ubora wa juu sana, lakini ni huduma inayoendeshwa
+        na watu wa kujitolea wakati wao wa mapumziko. Tafadhali ongea na
+        wauzaji wako wa vifaa na huduma kuhusu kupata huduma ya ndani na ya kuaminika iliyosanidiwa kwa ajili yako. Tazama pia <a href="/tos.html">masharti yetu
+        ya huduma</a>.
+
+        Tunapendekeza seva za saa kutoka
+        <a href="http://www.meinbergglobal.com/english/products/ntp-time-server.htm">Meinberg</a>,
+        lakini unaweza pia kupata seva za saa kutoka
+        <a href="http://www.endruntechnologies.com/NTP-Servers/gps-cdma-ntp.htm">End Run</a>,
+        <a href="http://spectracom.com/products-services/precision-timing#anchor-2172">Spectracom</a>
+        na wengine wengi.
+        </p>
+
+	<p><span class="hook">Ikiwa una anwani ya IP thabiti na muunganisho wa mtandao unaofaa</span> (kipimo data
+	si muhimu sana, lakini kinapaswa kuwa thabiti na si na mzigo mwingi), tafadhali
+	fikiria kuchangia seva yako kwenye pool ya seva. Haikugharimu zaidi ya
+	baiti mia chache kwa sekunde ya trafiki, lakini unasaidia mradi huu kuendelea.
+	Tafadhali <a href="/join.html">soma ukurasa wa kujiunga</a> kwa taarifa zaidi.
+	</p>
+
+	<p><span class="hook">Ikiwa mtoa huduma wako wa mtandao ana seva ya saa</span>, au ikiwa unajua seva nzuri ya saa
+	karibu nawe, unapaswa kutumia hiyo na si orodha hii - labda utapata
+	saa bora na utatumia rasilimali chache za mtandao. Ikiwa unajua seva moja tu ya saa
+	karibu nawe, bila shaka unaweza kutumia hiyo na mbili kutoka pool.ntp.org au kadhalika.</p>
+
+	<p><span class="hook">Mara chache inaweza kutokea kwamba umepewa seva ile ile ya saa mara mbili</span> -
+	kuanzisha upya seva ya NTP kwa kawaida kunasuluhisha tatizo hili. Ikiwa
+	unatumia kanda ya nchi, tafadhali kumbuka kwamba inaweza kuwa kwa sababu kuna seva moja tu
+	inayojulikana kwenye mradi - ni bora kutumia kanda ya bara
+	katika hali hiyo. Unaweza <a href="/zone">kuvinjari kanda</a> kuona ni
+	seva ngapi tunazo katika kila kanda.</p>
+
+	<p><span class="hook">Kuwa mwema</span>. Seva nyingi zinatolewa na watu wa kujitolea, na karibu seva zote za saa
+	kwa kweli ni seva za faili au barua pepe au wavuti ambazo pia zinaendesha NTP.
+	Kwa hivyo usitumie seva zaidi ya nne za saa katika usanidi wako, na usicheze
+	mbinu na <code>burst</code> au <code>minpoll</code> - unachopata ni mzigo
+        wa ziada kwenye seva za saa za kujitolea.</p>
+
+	<p><span class="hook">Hakikisha kuwa <i>usanidi wa eneo la saa</i> wa kompyuta yako ni sahihi</span>.
+	ntpd yenyewe haifanyi chochote kuhusu kanda za saa, inatumia UTC
+	ndani tu.</p>
+
+	<p><span class="hook">Ikiwa unasawazisha mtandao kwa pool.ntp.org</span>, tafadhali sanidi moja ya
+	kompyuta zako kama seva ya saa na usawazishe kompyuta nyingine kwa hiyo.
+	(utahitaji kusoma kidogo - si vigumu ingawa. Na kuna daima
+	<a href="news:comp.protocols.time.ntp">kikundi cha habari cha comp.protocols.time.ntp</a>.)</p>
+
+	<p class="thanks">Kwa wakati huu, ningependa kuwashukuru wale wanaotoa muda wao na seva za saa kwa
+	mtandao huu.</p>
+</div>

--- a/i18n/languages.json
+++ b/i18n/languages.json
@@ -96,6 +96,10 @@
   "sv": {
     "name": "Svenska"
   },
+  "sw": {
+    "name": "Kiswahili",
+    "testing": 1
+  },
   "th": {
     "name": "ภาษาไทย"
   },

--- a/i18n/sw.po
+++ b/i18n/sw.po
@@ -1,0 +1,136 @@
+msgid ""
+msgstr ""
+"Last-Translator: James Peru <admin@xcobean.co.ke>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: sw\n"
+
+msgid "go up"
+msgstr "rudi juu"
+
+# zone names
+msgid "Africa"
+msgstr "Afrika"
+
+msgid "Asia"
+msgstr "Asia"
+
+msgid "North America"
+msgstr "Amerika Kaskazini"
+
+msgid "South America"
+msgstr "Amerika Kusini"
+
+msgid "Europe"
+msgstr "Ulaya"
+
+msgid "Oceania"
+msgstr "Oceania"
+
+msgid "Global"
+msgstr "Ulimwengu"
+
+msgid "All Pool Servers"
+msgstr "Seva Zote za Pool"
+
+# navigation
+msgid "Translations"
+msgstr "Tafsiri"
+
+# index.html
+msgid  "Introduction"
+msgstr "Utangulizi"
+
+msgid  "Active Servers"
+msgstr "Seva Zinazofanya Kazi"
+
+msgid  "Links"
+msgstr "Viungo"
+
+msgid  "Terms of service"
+msgstr "Masharti ya huduma"
+
+msgid  "Subscribe in a reader"
+msgstr "Jiandikishe kwenye kisomaji"
+
+msgid  "Older news"
+msgstr "Habari za zamani"
+
+# mailinglists.html
+msgid  "archive"
+msgstr "kumbukumbu"
+
+msgid  "NTP Pool Forum"
+msgstr "Jukwaa la NTP Pool"
+
+msgid  "News site"
+msgstr "Tovuti ya habari"
+
+msgid  "Discussion list"
+msgstr "Orodha ya majadiliano"
+
+msgid  "Development"
+msgstr "Uendelezaji"
+
+msgid  "forum_description"
+msgstr "Maswali (na majibu) kuhusu NTP Pool, mapendekezo ya maboresho na mada zinazohusiana na utunzaji wa saa na uendeshaji wa seva za NTP."
+
+msgid  "news_description"
+msgstr "Matangazo na habari zinachapishwa kwenye tovuti ya habari au jukwaa."
+
+msgid  "development_list_description"
+msgstr "Majadiliano ya kiufundi zaidi (na kwa vitendo) kuhusu uendelezaji wa <a href=\"%1\">msimbo wa NTP Pool</a> na <a href=\"%2\">GeoDNS</a> yanafanyika kwenye <a href=\"%3\">jukwaa la uendelezaji</a>."
+
+# tpl/server.html
+msgid  "Back to the front page"
+msgstr "Rudi kwenye ukurasa wa mbele"
+
+msgid  "Find"
+msgstr "Tafuta"
+
+msgid  "Stats for %1"
+msgstr "Takwimu za %1"
+
+msgid  "Not active in the pool, monitoring only"
+msgstr "Haifanyi kazi kwenye pool, inafuatiliwa tu"
+
+msgid  "Zones:"
+msgstr "Kanda:"
+
+msgid  "This server is <span class=\"deletion\">scheduled for deletion</span> on %1."
+msgstr "Seva hii <span class=\"deletion\">imepangwa kufutwa</span> tarehe %1."
+
+msgid  "This server was <span class=\"deletion\">scheduled for deletion</span> on %1."
+msgstr "Seva hii <span class=\"deletion\">ilipangwa kufutwa</span> tarehe %1."
+
+msgid  "Current score: %1 (only servers with a score higher than %2 are used in the pool)"
+msgstr "Alama ya sasa: %1 (seva zenye alama zaidi ya %2 pekee ndizo zinazotumika kwenye pool)"
+
+msgid  "What do the graphs mean?"
+msgstr "Grafu hizi zinamaanisha nini?"
+
+msgid  "CSV log"
+msgstr "Kumbukumbu ya CSV"
+
+# tpl/navigation_sidebar.html
+msgid  "News"
+msgstr "Habari"
+
+msgid  "How do I <i>use</i> pool.ntp.org?"
+msgstr "Ninawezaje <i>kutumia</i> pool.ntp.org?"
+
+msgid  "How do I <i>join</i> pool.ntp.org?"
+msgstr "Ninawezaje <i>kujiunga</i> na pool.ntp.org?"
+
+msgid  "Information for vendors"
+msgstr "Taarifa kwa watengenezaji"
+
+msgid  "The mailing lists"
+msgstr "Jumuiya"
+
+msgid  "Additional links"
+msgstr "Viungo vya ziada"
+
+msgid  "Can you translate?"
+msgstr "Je, unaweza kutafsiri?"


### PR DESCRIPTION
## Summary
- Add Kiswahili (Swahili) translation for the NTP Pool website
- Kiswahili is spoken by over 100 million people across East Africa (Kenya, Tanzania, Uganda, DRC, etc.)
- This is the first East African language added to the NTP Pool

## Files
- `i18n/sw.po` — 42 translated strings
- `docs/ntppool/sw/homepage/intro.html` — homepage intro
- `docs/ntppool/sw/use.html` — usage instructions
- `docs/ntppool/sw/join.html` — join instructions
- `i18n/languages.json` — added `"sw"` entry with `"testing": 1`

## Context
We are running an NTP Pool server in Nairobi, Kenya (`102.212.230.8`) at the Kenya Internet Exchange Point (KIXP). Adding a Kiswahili translation makes the NTP Pool more accessible to the East African community.