### PR TITLE
Drop link to DNS query rate graphs from dns.html

### DIFF
--- a/docs/ntppool/tpl/dns.html
+++ b/docs/ntppool/tpl/dns.html
@@ -46,6 +46,4 @@ uptime: [% time_dur.duration(ns.status.up) | html %]<br>
 [% END %]
 </table>
 
-<a href="http://x.gfk.cc/ntppoolgraphs">DNS query rate graphs</a>
-
 </p>


### PR DESCRIPTION
As is, following it currently only leads to a 404 Not Found error page.