### PR TITLE
Adjust email response timeframe in vendor show page

### DIFF
--- a/docs/manage/tpl/vendor/show.html
+++ b/docs/manage/tpl/vendor/show.html
@@ -64,7 +64,7 @@
        [% ELSE %]
        <p>
         If your application hasn't been processed or responded to
-        within a week, please email the <a href="mailto:[% " vendors" | email %]?subject=Vendor zone [% vz.zone_name |
+        within a month, please email the <a href="mailto:[% " vendors" | email %]?subject=Vendor zone [% vz.zone_name |
             html %] application">vendor support</a> address.
        </p>
        [% END %]


### PR DESCRIPTION
According to my experience and some user feedback on forum, it looks the response delay can be longer than a couple of week.

I am proposing to adjust the timeframe, to avoid suspecting  email are not processed at all.

I hope this will save a bit of admin time and then contribute to reduce the bottleneck.

Relate-to: https://community.ntppool.org/t/application-for-vendor-zone-is-still-pending-for-5-weeks/1914
Related-to: https://community.ntppool.org/search?expanded=true&q=Status%3A%20pending