### PR TITLE
user deletion: delete all user sessions on deletion request

### DIFF
--- a/lib/NTPPool/Control/Manage.pm
+++ b/lib/NTPPool/Control/Manage.pm
@@ -75,10 +75,6 @@ sub init {
             }
         }
 
-        if ($self->user->deletion_on and $self->request->uri ne "/manage/logout") {
-            return $self->redirect($self->manage_url('/manage/logout'));
-        }
-
     }
 
     return OK;

--- a/lib/NTPPool/Control/Manage/Account.pm
+++ b/lib/NTPPool/Control/Manage/Account.pm
@@ -530,6 +530,10 @@ sub render_user_delete {
         );
         $task->save;
 
+        NP::Model->user_session->delete_user_sessions(
+            where => [user_id => $user->id],
+        );
+
         $db->commit or die "could not mark user deleted";
 
         my $param = {


### PR DESCRIPTION
Closes #253

Delete all active sessions when a user requests an account deletion, logging them out from all devices (Manage/Account.pm)
Removes the redirect to logout in Manage::init() that was previously handling users in pending deletion (Manage.pm)